### PR TITLE
Update navigation to fix namespace clash with existing webnn repo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_portile2 (2.5.3)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
@@ -72,6 +76,7 @@ GEM
     unicode-display_width (1.7.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,9 +1,9 @@
 - name: Home
   link: /
 - name: WebNN
-  link: /webnn/
+  link: /webnn-intro/
 - name: Model Loader
-  link: /modelloader/
+  link: /modelloader-intro/
 - name: Blog
   link: /blog/
 - name: Community

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,14 +33,14 @@
           <nav class="menu">
             <ol>
               <li class="menu-item">
-                <a class="link link--dia" href="{{ 'webnn' | relative_url }}">WebNN</a>
+                <a class="link link--dia" href="{{ 'webnn-intro' | relative_url }}">WebNN</a>
                 <ol class="sub-menu">
                   <li class="menu-item"><a href="{{ 'webnn-getstarted' | relative_url }}">Get Started</a></li>
                   <!-- <li class="menu-item"><a href="{{ 'webnn-spec' | relative_url }}">Spec</a></li> -->
                   <li class="menu-item"><a href="{{ 'webnn-samples' | relative_url }}">Samples</a></li>
                 </ol>
               </li>
-              <li class="menu-item"><a class="link link--dia" href="{{ 'modelloader' | relative_url }}">Model Loader</a></li>
+              <li class="menu-item"><a class="link link--dia" href="{{ 'modelloader-intro' | relative_url }}">Model Loader</a></li>
               <!-- <li class="menu-item"><a class="link link--dia" href="{{ 'blog' | relative_url }}">Blog</a></li> -->
               <li class="menu-item"><a class="link link--dia" href="{{ 'community' | relative_url }}">Community</a></li>
               <li class="menu-item">

--- a/modelloader-intro.md
+++ b/modelloader-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Model Loader
-permalink: /modelloader/
+permalink: /modelloader-intro/
 ---
 
 Model Loader is a proposed web API to load a custom, pre-trained machine learning model in a standard format, compile it for the available hardware, and apply it to example data in JavaScript in order to perform inference, like classification, regression, or ranking. The idea is to make it as easy as possible for web developers to use a custom, pre-built machine learning model in their web app, across devices and browsers.

--- a/webnn-intro.md
+++ b/webnn-intro.md
@@ -1,5 +1,5 @@
 ---
 layout: webnn
 title: WebNN
-permalink: /webnn/
+permalink: /webnn-intro/
 ---


### PR DESCRIPTION
Also update Gemfile.lock

FYI @ibelem, this is a minor fix to avoid clashing with the spec already hosted at `/webnn` in this GH org.