### PR TITLE
[Color Accessibility] Improve the contrast for texts, links and buttons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -53,7 +53,8 @@
       </div>
     </div>
     <div>
-      &copy; 2021 <a href="https://github.com/webmachinelearning/">{{ site.title | escape }}</a>
+      &#xA9; 2021 <a href="https://www.w3.org/">W3C</a> <sup>&#xAE;</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>)</a>
     </div>
 
   </div>

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -15,16 +15,16 @@ $background-color: rgb(249, 249, 249) !default;
 $background-color-dark: darken($background-color, 10%) !default;
 
 
-$brand-color:      #4777c0 !default;
+$brand-color:      #2555a0 !default;
 $brand-color0:      darken($brand-color, 20%) !default;
-$brand-color2:      #4777c0 !default;
+$brand-color2:      #3666b0 !default;
 $brand-color3:      #4fc3f7 !default;
 $brand-color4:      #b3e5fc !default;
 $brand-color5:      #e1f5fe !default;
 $brand-bg: rgba(242, 245, 281, 1.0) !default;
 $brand-bg2: rgba(242, 245, 281, 0.75) !default;
 
-$faq-color: #f76c6c !default;
+$faq-color: #c73c3c !default;
 
 $red-color:       #f44336 !default;
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -27,7 +27,7 @@
 .site-footer {
   margin-top: 2rem;
   padding: $spacing-unit 0;
-  background-image: linear-gradient(135deg, #3f69b8, $brand-color, #62d3fd);
+  background-image: linear-gradient(135deg, #3f69b8, $brand-color, #42b3dd);
   color: #fff;
   text-align: center;
 }


### PR DESCRIPTION
Sorry didn't see issues and PR opened by @dontcallmedom in my personal repo in time, fixed following issues based on @dontcallmedom's guidelines:

1. Set copyright to W3C, copyright can't be owned by the non-existent "Web Machine Learning".  -- based on https://github.com/ibelem/website/pull/3
2. the "running code" button has contrast ratio **2.9** when not in :hover state -> New contrast ratio is **5.07**
3. on the community page, the .title text color over the .headbg backgrouncolor has contrast ratio **4.1** -> New contrast ratio is **6.68**
4. the last stop of the gradient on the footer (62d3fd) creates a contrast ratio of **1.7** with white text over it - that affects at least the "follow us" link, -> **Improved**
5. maybe more links appearing on code and pre elements (such as Operand in the WebNN get started page) have contrasts **4.3** -> New contrast ratio is **6.99**

Many thanks @dontcallmedom ! @anssiko  PTAL :)