### PR TITLE
Update Google Analytics measurement (gtag) ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ twitter_username: webmachinelearning
 github_username:  webmachinelearning
 logo: https://avatars2.githubusercontent.com/u/42399997
 
-google_analytics: UA-147662084-1
+google_analytics: G-6TK7JD3KKY
 
 theme: minima
 plugins:


### PR DESCRIPTION
Update the Google Analytics measurement (gtag) ID for tracking the website and new WebNN samples data. The UA-147662084-1 was used for the legacy https://intel.github.io/webml-polyfill/examples, we need a new ID for https://webmachinelearning.github.io/.

G-6TK7JD3KKY

Also added @anssiko as the Google Analytics administrator. PTAL.