### PR TITLE
UI tuning and add blog link back

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
           </ul>
           <ul>
             <li><a class="footer_link underline up" href="{{ 'community' | relative_url }}">Community</a></li>
-            <!-- <li><a class="footer_link underline" href="{{ 'blog' | relative_url }}">Blog</a></li> -->
+            <li><a class="footer_link underline" href="{{ 'blog' | relative_url }}">Blog</a></li>
             <li><a class="footer_link underline" href="{{ 'doc' | relative_url }}">Documentation</a>
             <!-- <li><a class="footer_link underline" href="{{ 'faq' | relative_url }}">FAQ</a> -->
             <li><a class="footer_link underline" href="{{ 'logos' | relative_url }}">Logos</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,10 +41,10 @@
                 </ol>
               </li>
               <li class="menu-item"><a class="link link--dia" href="{{ 'model-loader-intro' | relative_url }}">Model Loader</a></li>
-              <!-- <li class="menu-item"><a class="link link--dia" href="{{ 'blog' | relative_url }}">Blog</a></li> -->
+              <li class="menu-item"><a class="link link--dia" href="{{ 'blog' | relative_url }}">Blog</a></li>
               <li class="menu-item"><a class="link link--dia" href="{{ 'community' | relative_url }}">Community</a></li>
               <li class="menu-item">
-                <a class="link link--dia faq" href="https://github.com/webmachinelearning/">Running Code</a>
+                <a class="link link--dia faq" href="https://github.com/webmachinelearning/">The Running Code</a>
                 <ol class="sub-menu">
                   <li class="menu-item"><a href="https://github.com/webmachinelearning/webnn-polyfill">WebNN Polyfill</a></li>
                   <li class="menu-item"><a href="https://github.com/webmachinelearning/webnn-samples">WebNN Samples</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,7 @@
               <li class="menu-item"><a class="link link--dia" href="{{ 'blog' | relative_url }}">Blog</a></li>
               <li class="menu-item"><a class="link link--dia" href="{{ 'community' | relative_url }}">Community</a></li>
               <li class="menu-item">
-                <a class="link link--dia faq" href="https://github.com/webmachinelearning/">The Running Code</a>
+                <a class="link link--dia faq" href="https://github.com/webmachinelearning/">GitHub</a>
                 <ol class="sub-menu">
                   <li class="menu-item"><a href="https://github.com/webmachinelearning/webnn-polyfill">WebNN Polyfill</a></li>
                   <li class="menu-item"><a href="https://github.com/webmachinelearning/webnn-samples">WebNN Samples</a></li>

--- a/_sass/nav.scss
+++ b/_sass/nav.scss
@@ -273,7 +273,7 @@ nav a {
 .sub-menu:before {
     content: "";
     position: absolute;
-    left: 68px;
+    left: 54px;
     top: -8px;
     width: 0;
     height: 0;
@@ -309,10 +309,6 @@ nav a {
 .sub-menu .menu-item:hover {
     color: #fff;
     background: $brand-color;
-}
-
-.sub-menu .menu-item a {
-    padding: 0 0.75rem;
 }
 
 .sub-menu .menu-item:hover a,

--- a/_sass/nav.scss
+++ b/_sass/nav.scss
@@ -70,6 +70,12 @@ nav a {
     transition-timing-function: cubic-bezier(0.2, 0, 0.3, 1);
 }
 
+.logo .link--dia:hover::before,
+.logo .link--dia:hover::after {
+    opacity: 0;
+    transform: none;
+}
+
 .link--dia::after {
     content: '';
     top: calc(100% + 4px);


### PR DESCRIPTION
- [x] Remove unexpected underlines animation when hover on WebML log in top left of page
- [x] Change the link "Running Code" to "The Running Code", @kenny-y thought "Running code" without "the" will cause misunderstanding. Also need @anssiko 's comment.
- [x] Add "Blog" links back. I don't remember why we removed the blog links at the time, I think @Honry or @brucedai could write a blog about publishing webnn-polyfill to npm there.

@anssiko @Honry PTAL