### PR TITLE
Refer to the latest published version of the WebNN API

### DIFF
--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: " en" }}">
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
 {%- include head.html -%}
 

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<html lang="{{ page.lang | default: site.lang | default: " en" }}">
 
 {%- include head.html -%}
 
@@ -45,7 +45,7 @@
                 </path>
               </svg>Early Implementations</li>
           </ul>
-          <a class="learn" href="https://webmachinelearning.github.io/webnn/"> Read the specification
+          <a class="learn" href="https://www.w3.org/TR/webnn/"> Read the specification
             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               class="w-4 h-4" viewBox="0 0 24 24">
               <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -176,13 +176,13 @@
               Group</a></p>
         </div>
         <div class="fx"><svg viewBox="0 0 320 512">
-          <path fill="currentColor"
-            d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
-          </path>
-        </svg>
-        <p>If representing a <a href="https://www.w3.org/Consortium/Member/List">W3C Member</a>, also <a
-            href="https://www.w3.org/2004/01/pp-impl/130674/join">join the Working Group</a></p>
-      </div>
+            <path fill="currentColor"
+              d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
+            </path>
+          </svg>
+          <p>If representing a <a href="https://www.w3.org/Consortium/Member/List">W3C Member</a>, also <a
+              href="https://www.w3.org/2004/01/pp-impl/130674/join">join the Working Group</a></p>
+        </div>
 
         <div class="fx"><svg viewBox="0 0 320 512">
             <path fill="green"
@@ -197,28 +197,29 @@
 
       <div class="cap">
         <p class="title">How to Contribute</p>
-        <p class="subtitle">specifications and related projects in <a href="https://github.com/webmachinelearning/">GitHub</a> welcome your contributions!</p>
+        <p class="subtitle">specifications and related projects in <a
+            href="https://github.com/webmachinelearning/">GitHub</a> welcome your contributions!</p>
       </div>
 
       <ul class="c4">
         <li><svg viewBox="0 0 320 512">
-          <path fill="currentColor"
-            d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
-          </path>
-        </svg> <a href="https://github.com/webmachinelearning/webnn/">webnn</a>
-      </li>
+            <path fill="currentColor"
+              d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
+            </path>
+          </svg> <a href="https://github.com/webmachinelearning/webnn/">webnn</a>
+        </li>
         <li><svg viewBox="0 0 320 512">
-          <path fill="currentColor"
-            d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
-          </path>
-        </svg> <a href="https://github.com/webmachinelearning/model-loader/">model-loader</a>
-      </li>
+            <path fill="currentColor"
+              d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
+            </path>
+          </svg> <a href="https://github.com/webmachinelearning/model-loader/">model-loader</a>
+        </li>
         <li><svg viewBox="0 0 320 512">
-          <path fill="currentColor"
-            d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
-          </path>
-        </svg> <a href="https://github.com/webmachinelearning/meetings/">meetings</a>
-      </li>
+            <path fill="currentColor"
+              d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
+            </path>
+          </svg> <a href="https://github.com/webmachinelearning/meetings/">meetings</a>
+        </li>
         <li><svg viewBox="0 0 320 512">
             <path fill="currentColor"
               d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
@@ -235,17 +236,18 @@
               d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
             </path>
           </svg> <a href="https://github.com/webmachinelearning/webnn-native">webnn-native</a></li>
-          <li><svg viewBox="0 0 320 512">
+        <li><svg viewBox="0 0 320 512">
             <path fill="currentColor"
               d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
             </path>
           </svg> <a href="https://github.com/webmachinelearning/proposals">proposals</a></li>
-          <li><svg viewBox="0 0 320 512">
+        <li><svg viewBox="0 0 320 512">
             <path fill="currentColor"
               d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z">
             </path>
-          </svg> <a href="https://github.com/webmachinelearning/webmachinelearning.github.io">including this website 😊</a></li>
-          </ul>
+          </svg> <a href="https://github.com/webmachinelearning/webmachinelearning.github.io">including this website
+            😊</a></li>
+      </ul>
 
       {{ content }}
 

--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: " en" }}">
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
 {%- include head.html -%}
 

--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<html lang="{{ page.lang | default: site.lang | default: " en" }}">
 
 {%- include head.html -%}
 
@@ -42,8 +42,8 @@
                 <li>Noise suppression</li>
               </ul>
 
-              <p>These use cases and more are elaborated in the <a
-                  href="https://webmachinelearning.github.io/webnn/#usecases">use cases section of the API
+              <p>These use cases and more are elaborated in the <a href="https://www.w3.org/TR/webnn/#usecases">use
+                  cases section of the API
                   specification</a>.</p>
 
               <p>While some of these use cases can be implemented in a constrained manner with existing Web APIs (e.g.
@@ -53,9 +53,9 @@
                 hardware accelerators constraints the scope of experiences and leads to inefficient implementations on
                 modern hardware. This disadvantages the web platform in comparison to native platforms.</p>
 
-              <p>The design process of the <a href="http://webmachinelearning.github.io/webnn/">Web Neural Network
-                  API</a> (WebNN API) started by identifying the <a
-                  href="https://webmachinelearning.github.io/webnn/#usecases">key use cases</a> working with the <a
+              <p>The design process of the <a href="https://www.w3.org/TR/webnn/">Web Neural Network
+                  API</a> (WebNN API) started by identifying the <a href="https://www.w3.org/TR/webnn/#usecases">key use
+                  cases</a> working with the <a
                   href="https://www.w3.org/community/webmachinelearning/participants">diverse participants</a> including
                 major browser vendors, key ML JS frameworks, interested hardware vendors, and web developers. After
                 identification of the key use cases, the group worked down the levels of abstraction and <a
@@ -147,7 +147,7 @@
 
             <p>Depending on the underlying hardware capabilities, these platform APIs may make use of CPU parallelism,
               general-purpose GPU, or dedicated hardware accelerators for machine learning. The WebNN API provides <a
-                href="https://webmachinelearning.github.io/webnn/#usecase-perf-adapt">performance adaptation</a> options
+                href="https://www.w3.org/TR/webnn/#usecase-perf-adapt">performance adaptation</a> options
               but remains hardware agnostic.</p>
           </div>
         </div>
@@ -267,7 +267,7 @@
               decomposed operations are also defined. This way, a newly-conceived function may be represented as a
               network of our decomposed operations, while a standard function can also be fully supported by the
               underlying platforms. An elaborate example of this principle is in the way we define the specification of
-              the <a href="https://webmachinelearning.github.io/webnn/#api-modelbuilder-grucell">gruCell</a> operation
+              the <a href="https://www.w3.org/TR/webnn/#api-modelbuilder-grucell">gruCell</a> operation
               as described in its notes.</p>
 
           </div>
@@ -306,8 +306,9 @@
         </div>
 
         <div class="accordion-item">
-          <button id="accordion-button-4" aria-expanded="false"><span class="accordion-title">Why not define a model format that
-            covers both topology and weights?</span><span class="icon" aria-hidden="true"></span></button>
+          <button id="accordion-button-4" aria-expanded="false"><span class="accordion-title">Why not define a model
+              format that
+              covers both topology and weights?</span><span class="icon" aria-hidden="true"></span></button>
           <div class="accordion-content">
             <p>Defining a model format should simplify model loading, but it was explicitly stated as a non-goal for
               WebNN API to directly support model format as we believe formats should be left with the framework or the

--- a/_posts/2020-03-17-noise-suppression-net-v2.md
+++ b/_posts/2020-03-17-noise-suppression-net-v2.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: 'Noise Suppression Net 2 (NSNet2)'
+title: "Noise Suppression Net 2 (NSNet2)"
 date: 2021-03-17 20:42:03 +0800
 author: Web Machine Learning Working Group
 avatar: https://avatars.githubusercontent.com/u/379216?s=200&v=4
 categories: get-started
 ---
 
-In the WebNN API, the [`Operand`](https://webmachinelearning.github.io/webnn/#operand) objects represent input, output, and constant multi-dimensional arrays known as [tensors](https://mathworld.wolfram.com/Tensor.html). The [`NeuralNetworkContext`](https://webmachinelearning.github.io/webnn/#api-neuralnetworkcontext) defines a set of operations that facilitate the construction and execution of this computational graph. Such operations may be accelerated with dedicated hardware such as the GPUs, CPUs with extensions for deep learning, or dedicated ML accelerators. These operations defined by the WebNN API are required by [models](https://github.com/webmachinelearning/webnn/blob/master/op_compatibility/first_wave_models.md) that address key application use cases. Additionally, the WebNN API provides affordances to builder a computational graph, compile the graph, execute the graph, and integrate the graph with other Web APIs that provide input data to the graph e.g. media APIs for image or video frames and sensor APIs for sensory data.
+In the WebNN API, the [`Operand`](https://www.w3.org/TR/webnn/#operand) objects represent input, output, and constant multi-dimensional arrays known as [tensors](https://mathworld.wolfram.com/Tensor.html). The [`NeuralNetworkContext`](https://www.w3.org/TR/webnn/#api-mlcontext) defines a set of operations that facilitate the construction and execution of this computational graph. Such operations may be accelerated with dedicated hardware such as the GPUs, CPUs with extensions for deep learning, or dedicated ML accelerators. These operations defined by the WebNN API are required by [models](https://github.com/webmachinelearning/webnn/blob/master/op_compatibility/first_wave_models.md) that address key application use cases. Additionally, the WebNN API provides affordances to builder a computational graph, compile the graph, execute the graph, and integrate the graph with other Web APIs that provide input data to the graph e.g. media APIs for image or video frames and sensor APIs for sensory data.
 
-This [example](https://webmachinelearning.github.io/webnn/#examples) builds, compiles, and executes a graph comprised of three ops, takes four inputs and returns one output.
+This [example](https://www.w3.org/TR/webnn/#examples) builds, compiles, and executes a graph comprised of three ops, takes four inputs and returns one output.
 
 <!-- more -->
 
-There are many important [application use cases](https://webmachinelearning.github.io/webnn/#usecases-application) for high-performance neural network inference. One such use case is deep-learning noise suppression (DNS) in web-based video conferencing. The following sample shows how the [NSNet2](https://github.com/microsoft/DNS-Challenge/tree/master/NSNet2-baseline) baseline implementation of deep learning-based noise suppression model may be implemented using the WebNN API.
+There are many important [application use cases](https://www.w3.org/TR/webnn/#usecases-application) for high-performance neural network inference. One such use case is deep-learning noise suppression (DNS) in web-based video conferencing. The following sample shows how the [NSNet2](https://github.com/microsoft/DNS-Challenge/tree/master/NSNet2-baseline) baseline implementation of deep learning-based noise suppression model may be implemented using the WebNN API.
 
 ```js
-// Noise Suppression Net 2 (NSNet2) 
+// Noise Suppression Net 2 (NSNet2)
 // Baseline Model for Deep Noise Suppression Challenge (DNS) 2021.
 export class NSNet2 {
   constructor() {
@@ -30,39 +30,104 @@ export class NSNet2 {
     const nn = navigator.ml.getNeuralNetworkContext();
     const builder = nn.createModelBuilder();
     // Create constants by loading pre-trained data from .npy files.
-    const weight172 = await buildConstantByNpy(builder, baseUrl + '172.npy');
-    const biasFcIn0 = await buildConstantByNpy(builder, baseUrl + 'fc_in_0_bias.npy');
-    const weight192 = await buildConstantByNpy(builder, baseUrl + '192.npy');
-    const recurrentWeight193 = await buildConstantByNpy(builder, baseUrl + '193.npy');
-    const bias194 = await buildConstantByNpy(builder, baseUrl + '194_0.npy');
-    const recurrentBias194 = await buildConstantByNpy(builder, baseUrl + '194_1.npy');
-    const weight212 = await buildConstantByNpy(builder, baseUrl + '212.npy');
-    const recurrentWeight213 = await buildConstantByNpy(builder, baseUrl + '213.npy');
-    const bias214 = await buildConstantByNpy(builder, baseUrl + '214_0.npy');
-    const recurrentBias214 = await buildConstantByNpy(builder, baseUrl + '214_1.npy');
-    const weight215 = await buildConstantByNpy(builder, baseUrl + '215.npy');
-    const biasFcOut0 = await buildConstantByNpy(builder, baseUrl + 'fc_out_0_bias.npy');
-    const weight216 = await buildConstantByNpy(builder, baseUrl + '216.npy');
-    const biasFcOut2 = await buildConstantByNpy(builder, baseUrl + 'fc_out_2_bias.npy');
-    const weight217 = await buildConstantByNpy(builder, baseUrl + '217.npy');
-    const biasFcOut4 = await buildConstantByNpy(builder, baseUrl + 'fc_out_4_bias.npy');
+    const weight172 = await buildConstantByNpy(builder, baseUrl + "172.npy");
+    const biasFcIn0 = await buildConstantByNpy(
+      builder,
+      baseUrl + "fc_in_0_bias.npy"
+    );
+    const weight192 = await buildConstantByNpy(builder, baseUrl + "192.npy");
+    const recurrentWeight193 = await buildConstantByNpy(
+      builder,
+      baseUrl + "193.npy"
+    );
+    const bias194 = await buildConstantByNpy(builder, baseUrl + "194_0.npy");
+    const recurrentBias194 = await buildConstantByNpy(
+      builder,
+      baseUrl + "194_1.npy"
+    );
+    const weight212 = await buildConstantByNpy(builder, baseUrl + "212.npy");
+    const recurrentWeight213 = await buildConstantByNpy(
+      builder,
+      baseUrl + "213.npy"
+    );
+    const bias214 = await buildConstantByNpy(builder, baseUrl + "214_0.npy");
+    const recurrentBias214 = await buildConstantByNpy(
+      builder,
+      baseUrl + "214_1.npy"
+    );
+    const weight215 = await buildConstantByNpy(builder, baseUrl + "215.npy");
+    const biasFcOut0 = await buildConstantByNpy(
+      builder,
+      baseUrl + "fc_out_0_bias.npy"
+    );
+    const weight216 = await buildConstantByNpy(builder, baseUrl + "216.npy");
+    const biasFcOut2 = await buildConstantByNpy(
+      builder,
+      baseUrl + "fc_out_2_bias.npy"
+    );
+    const weight217 = await buildConstantByNpy(builder, baseUrl + "217.npy");
+    const biasFcOut4 = await buildConstantByNpy(
+      builder,
+      baseUrl + "fc_out_4_bias.npy"
+    );
     // Build up the network.
-    const input = builder.input('input', {type: 'float32', dimensions: [batchSize, frames, this.frameSize]});
-    const relu20 = builder.relu(builder.add(builder.matmul(input, weight172), biasFcIn0));
-    const transpose31 = builder.transpose(relu20, {permutation: [1, 0, 2]});
-    const initialState92 = builder.input('initialState92', {type: 'float32', dimensions: [1, batchSize, this.hiddenSize]});
-    const [gru94, gru93] = builder.gru(transpose31, weight192, recurrentWeight193, frames, this.hiddenSize,
-        {bias: bias194, recurrentBias: recurrentBias194, initialHiddenState: initialState92, returnSequence: true});
-    const squeeze95 = builder.squeeze(gru93, {axes: [1]});
-    const initialState155 = builder.input('initialState155', {type: 'float32', dimensions: [1, batchSize, this.hiddenSize]});
-    const [gru157, gru156] = builder.gru(squeeze95, weight212, recurrentWeight213, frames, this.hiddenSize,
-        {bias: bias214, recurrentBias: recurrentBias214, initialHiddenState: initialState155, returnSequence: true});
-    const squeeze158 = builder.squeeze(gru156, {axes: [1]});
-    const transpose159 = builder.transpose(squeeze158, {permutation: [1, 0, 2]});
-    const relu163 = builder.relu(builder.add(builder.matmul(transpose159, weight215), biasFcOut0));
-    const relu167 = builder.relu(builder.add(builder.matmul(relu163, weight216), biasFcOut2));
-    const output = builder.sigmoid(builder.add(builder.matmul(relu167, weight217), biasFcOut4));
-    this.model = builder.createModel({output, gru94, gru157});
+    const input = builder.input("input", {
+      type: "float32",
+      dimensions: [batchSize, frames, this.frameSize],
+    });
+    const relu20 = builder.relu(
+      builder.add(builder.matmul(input, weight172), biasFcIn0)
+    );
+    const transpose31 = builder.transpose(relu20, { permutation: [1, 0, 2] });
+    const initialState92 = builder.input("initialState92", {
+      type: "float32",
+      dimensions: [1, batchSize, this.hiddenSize],
+    });
+    const [gru94, gru93] = builder.gru(
+      transpose31,
+      weight192,
+      recurrentWeight193,
+      frames,
+      this.hiddenSize,
+      {
+        bias: bias194,
+        recurrentBias: recurrentBias194,
+        initialHiddenState: initialState92,
+        returnSequence: true,
+      }
+    );
+    const squeeze95 = builder.squeeze(gru93, { axes: [1] });
+    const initialState155 = builder.input("initialState155", {
+      type: "float32",
+      dimensions: [1, batchSize, this.hiddenSize],
+    });
+    const [gru157, gru156] = builder.gru(
+      squeeze95,
+      weight212,
+      recurrentWeight213,
+      frames,
+      this.hiddenSize,
+      {
+        bias: bias214,
+        recurrentBias: recurrentBias214,
+        initialHiddenState: initialState155,
+        returnSequence: true,
+      }
+    );
+    const squeeze158 = builder.squeeze(gru156, { axes: [1] });
+    const transpose159 = builder.transpose(squeeze158, {
+      permutation: [1, 0, 2],
+    });
+    const relu163 = builder.relu(
+      builder.add(builder.matmul(transpose159, weight215), biasFcOut0)
+    );
+    const relu167 = builder.relu(
+      builder.add(builder.matmul(relu163, weight216), biasFcOut2)
+    );
+    const output = builder.sigmoid(
+      builder.add(builder.matmul(relu167, weight217), biasFcOut4)
+    );
+    this.model = builder.createModel({ output, gru94, gru157 });
   }
 
   async compile(options) {
@@ -71,13 +136,13 @@ export class NSNet2 {
 
   async compute(inputBuffer, initialState92Buffer, initialState155Buffer) {
     const inputs = {
-      input: {buffer: inputBuffer},
-      initialState92: {buffer: initialState92Buffer},
-      initialState155: {buffer: initialState155Buffer},
+      input: { buffer: inputBuffer },
+      initialState92: { buffer: initialState92Buffer },
+      initialState155: { buffer: initialState155Buffer },
     };
     return await this.compiledModel.compute(inputs);
   }
 }
 ```
 
-Try the live version of the [WebNN NSNet2 example](https://webmachinelearning.github.io/webnn-samples/nsnet2/).  This live version builds upon [nsnet2.js](https://github.com/webmachinelearning/webnn-samples/blob/master/nsnet2/nsnet2.js) that implements the above code snippet as a JS module.
+Try the live version of the [WebNN NSNet2 example](https://webmachinelearning.github.io/webnn-samples/nsnet2/). This live version builds upon [nsnet2.js](https://github.com/webmachinelearning/webnn-samples/blob/master/nsnet2/nsnet2.js) that implements the above code snippet as a JS module.

--- a/_posts/2020-03-17-noise-suppression-net-v2.md
+++ b/_posts/2020-03-17-noise-suppression-net-v2.md
@@ -20,70 +20,97 @@ There are many important [application use cases](https://www.w3.org/TR/webnn/#us
 // Baseline Model for Deep Noise Suppression Challenge (DNS) 2021.
 export class NSNet2 {
   constructor() {
-    this.model = null;
-    this.compiledModel = null;
+    this.context_ = null;
+    this.builder_ = null;
+    this.graph_ = null;
     this.frameSize = 161;
     this.hiddenSize = 400;
   }
 
-  async load(baseUrl, batchSize, frames) {
-    const nn = navigator.ml.getNeuralNetworkContext();
-    const builder = nn.createModelBuilder();
+  async load(contextOptions, baseUrl, batchSize, frames) {
+    this.context_ = await navigator.ml.createContext(contextOptions);
+    this.builder_ = new MLGraphBuilder(this.context_);
     // Create constants by loading pre-trained data from .npy files.
-    const weight172 = await buildConstantByNpy(builder, baseUrl + "172.npy");
+    const weight172 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "172.npy"
+    );
     const biasFcIn0 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "fc_in_0_bias.npy"
     );
-    const weight192 = await buildConstantByNpy(builder, baseUrl + "192.npy");
+    const weight192 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "192.npy"
+    );
     const recurrentWeight193 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "193.npy"
     );
-    const bias194 = await buildConstantByNpy(builder, baseUrl + "194_0.npy");
+    const bias194 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "194_0.npy"
+    );
     const recurrentBias194 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "194_1.npy"
     );
-    const weight212 = await buildConstantByNpy(builder, baseUrl + "212.npy");
+    const weight212 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "212.npy"
+    );
     const recurrentWeight213 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "213.npy"
     );
-    const bias214 = await buildConstantByNpy(builder, baseUrl + "214_0.npy");
+    const bias214 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "214_0.npy"
+    );
     const recurrentBias214 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "214_1.npy"
     );
-    const weight215 = await buildConstantByNpy(builder, baseUrl + "215.npy");
+    const weight215 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "215.npy"
+    );
     const biasFcOut0 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "fc_out_0_bias.npy"
     );
-    const weight216 = await buildConstantByNpy(builder, baseUrl + "216.npy");
+    const weight216 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "216.npy"
+    );
     const biasFcOut2 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "fc_out_2_bias.npy"
     );
-    const weight217 = await buildConstantByNpy(builder, baseUrl + "217.npy");
+    const weight217 = await buildConstantByNpy(
+      this.builder_,
+      baseUrl + "217.npy"
+    );
     const biasFcOut4 = await buildConstantByNpy(
-      builder,
+      this.builder_,
       baseUrl + "fc_out_4_bias.npy"
     );
     // Build up the network.
-    const input = builder.input("input", {
+    const input = this.builder_.input("input", {
       type: "float32",
       dimensions: [batchSize, frames, this.frameSize],
     });
-    const relu20 = builder.relu(
-      builder.add(builder.matmul(input, weight172), biasFcIn0)
+    const relu20 = this.builder_.relu(
+      this.builder_.add(this.builder_.matmul(input, weight172), biasFcIn0)
     );
-    const transpose31 = builder.transpose(relu20, { permutation: [1, 0, 2] });
-    const initialState92 = builder.input("initialState92", {
+    const transpose31 = this.builder_.transpose(relu20, {
+      permutation: [1, 0, 2],
+    });
+    const initialState92 = this.builder_.input("initialState92", {
       type: "float32",
       dimensions: [1, batchSize, this.hiddenSize],
     });
-    const [gru94, gru93] = builder.gru(
+    const [gru94, gru93] = this.builder_.gru(
       transpose31,
       weight192,
       recurrentWeight193,
@@ -96,12 +123,12 @@ export class NSNet2 {
         returnSequence: true,
       }
     );
-    const squeeze95 = builder.squeeze(gru93, { axes: [1] });
-    const initialState155 = builder.input("initialState155", {
+    const squeeze95 = this.builder_.squeeze(gru93, { axes: [1] });
+    const initialState155 = this.builder_.input("initialState155", {
       type: "float32",
       dimensions: [1, batchSize, this.hiddenSize],
     });
-    const [gru157, gru156] = builder.gru(
+    const [gru157, gru156] = this.builder_.gru(
       squeeze95,
       weight212,
       recurrentWeight213,
@@ -114,33 +141,49 @@ export class NSNet2 {
         returnSequence: true,
       }
     );
-    const squeeze158 = builder.squeeze(gru156, { axes: [1] });
-    const transpose159 = builder.transpose(squeeze158, {
+    const squeeze158 = this.builder_.squeeze(gru156, { axes: [1] });
+    const transpose159 = this.builder_.transpose(squeeze158, {
       permutation: [1, 0, 2],
     });
-    const relu163 = builder.relu(
-      builder.add(builder.matmul(transpose159, weight215), biasFcOut0)
+    const relu163 = this.builder_.relu(
+      this.builder_.add(
+        this.builder_.matmul(transpose159, weight215),
+        biasFcOut0
+      )
     );
-    const relu167 = builder.relu(
-      builder.add(builder.matmul(relu163, weight216), biasFcOut2)
+    const relu167 = this.builder_.relu(
+      this.builder_.add(this.builder_.matmul(relu163, weight216), biasFcOut2)
     );
-    const output = builder.sigmoid(
-      builder.add(builder.matmul(relu167, weight217), biasFcOut4)
+    const output = this.builder_.sigmoid(
+      this.builder_.add(this.builder_.matmul(relu167, weight217), biasFcOut4)
     );
-    this.model = builder.createModel({ output, gru94, gru157 });
+    return { output, gru94, gru157 };
   }
 
-  async compile(options) {
-    this.compiledModel = await this.model.compile(options);
+  async build(outputOperand) {
+    this.graph_ = await this.builder_.build(outputOperand);
   }
 
-  async compute(inputBuffer, initialState92Buffer, initialState155Buffer) {
+  async compute(
+    inputBuffer,
+    initialState92Buffer,
+    initialState155Buffer,
+    outputBuffer,
+    gru94Buffer,
+    gru157Buffer
+  ) {
     const inputs = {
-      input: { buffer: inputBuffer },
-      initialState92: { buffer: initialState92Buffer },
-      initialState155: { buffer: initialState155Buffer },
+      input: inputBuffer,
+      initialState92: initialState92Buffer,
+      initialState155: initialState155Buffer,
     };
-    return await this.compiledModel.compute(inputs);
+    const outputs = {
+      output: outputBuffer,
+      gru94: gru94Buffer,
+      gru157: gru157Buffer,
+    };
+    const results = await this.context_.compute(this.graph_, inputs, outputs);
+    return results.outputs;
   }
 }
 ```

--- a/_posts/2021-03-25-webnn-native-build-and-run.md
+++ b/_posts/2021-03-25-webnn-native-build-and-run.md
@@ -1,34 +1,34 @@
 ---
 layout: post
-title:  "WebNN-Native Build and Run"
-date:   2021-03-25 18:00:00 +0800
+title: "WebNN-Native Build and Run"
+date: 2021-03-25 18:00:00 +0800
 author: Ningxin, Junwei, Bruce and Mingming
 avatar: https://avatars.githubusercontent.com/u/1531742?v=4
 categories: doc
 toc: true
 ---
 
-WebNN-native is a native implementation of the [Web Neural Network API](https://webmachinelearning.github.io/webnn/).
+WebNN-native is a native implementation of the [Web Neural Network API](https://www.w3.org/TR/webnn/).
 
 It provides several building blocks:
 
- - **WebNN C/C++ headers** that applications and other building blocks use.
-   - The `webnn.h` that is an one-to-one mapping with the WebNN IDL.
-   - A C++ wrapper for the `webnn.h`
- - **Backend implementations** that use platforms' ML APIs:
-   - **DirectML** on Windows 10
-   - **OpenVINO** on Windows 10 and Linux
-   - **oneDNN** on Windows 10 and Linux
-   - **XNNPACK** on Windows 10 and Linux
-   - _Other backends are to be added_
+- **WebNN C/C++ headers** that applications and other building blocks use.
+  - The `webnn.h` that is an one-to-one mapping with the WebNN IDL.
+  - A C++ wrapper for the `webnn.h`
+- **Backend implementations** that use platforms' ML APIs:
+  - **DirectML** on Windows 10
+  - **OpenVINO** on Windows 10 and Linux
+  - **oneDNN** on Windows 10 and Linux
+  - **XNNPACK** on Windows 10 and Linux
+  - _Other backends are to be added_
 
 <!-- more -->
 
 WebNN-native uses the code of other open source projects:
 
- * The code generator and infrastructure code of [Dawn](https://dawn.googlesource.com/dawn/) project.
- * The DirectMLX and device wrapper of [DirectML](https://github.com/microsoft/DirectML) project.
- * The [XNNPACK](https://github.com/google/XNNPACK)
+- The code generator and infrastructure code of [Dawn](https://dawn.googlesource.com/dawn/) project.
+- The DirectMLX and device wrapper of [DirectML](https://github.com/microsoft/DirectML) project.
+- The [XNNPACK](https://github.com/google/XNNPACK)
 
 ## Build and Run
 
@@ -39,7 +39,8 @@ WebNN-native uses the Chromium build system and dependency management so you nee
 [install depot_tools]: http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 
 **Notes**:
- * On Windows, you'll need to set the environment variable `DEPOT_TOOLS_WIN_TOOLCHAIN=0`. This tells depot_tools to use your locally installed version of Visual Studio (by default, depot_tools will try to download a Google-internal version).
+
+- On Windows, you'll need to set the environment variable `DEPOT_TOOLS_WIN_TOOLCHAIN=0`. This tells depot_tools to use your locally installed version of Visual Studio (by default, depot_tools will try to download a Google-internal version).
 
 ### Get the code
 
@@ -75,7 +76,8 @@ To build with XNNPACK backend, set build option `webnn_enable_xnnpack=true`.
 Then use `ninja -C out/Release` or `ninja -C out/Debug` to build WebNN-native.
 
 **Notes**
- * To build with XNNPACK backend, please build XNNPACK first, e.g. by [`XNNPACK/scripts/build-local.sh`](https://github.com/google/XNNPACK/blob/master/scripts/build-local.sh).
+
+- To build with XNNPACK backend, please build XNNPACK first, e.g. by [`XNNPACK/scripts/build-local.sh`](https://github.com/google/XNNPACK/blob/master/scripts/build-local.sh).
 
 ### Run tests
 
@@ -84,8 +86,9 @@ Run unit tests, for example `./out/Release/webnn_unittests`.
 Run end2end tests, for example `./out/Release/webnn_end2end_tests`.
 
 **Notes**:
- * For OpenVINO backend, please [install 2021.2 version](https://docs.openvinotoolkit.org/2021.2/openvino_docs_install_guides_installing_openvino_linux.html#install-openvino) and [set the environment variables](https://docs.openvinotoolkit.org/2021.2/openvino_docs_install_guides_installing_openvino_linux.html#set-the-environment-variables) before running the end2end tests.
- * For oneDNN backend on Linux, please set the `LD_LIBRARY_PATH` environment variable to the out folder before running the end2end tests, e.g. `LD_LIBRARY_PATH=./out/Release ./out/Release/webnn_end2end_tests`.
+
+- For OpenVINO backend, please [install 2021.2 version](https://docs.openvinotoolkit.org/2021.2/openvino_docs_install_guides_installing_openvino_linux.html#install-openvino) and [set the environment variables](https://docs.openvinotoolkit.org/2021.2/openvino_docs_install_guides_installing_openvino_linux.html#set-the-environment-variables) before running the end2end tests.
+- For oneDNN backend on Linux, please set the `LD_LIBRARY_PATH` environment variable to the out folder before running the end2end tests, e.g. `LD_LIBRARY_PATH=./out/Release ./out/Release/webnn_end2end_tests`.
 
 ## License
 

--- a/_posts/2021-04-20-w3c-launches-the-web-machine-learning-working-group.md
+++ b/_posts/2021-04-20-w3c-launches-the-web-machine-learning-working-group.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title:  "W3C Launches the Web Machine Learning Working Group"
-date:   2021-04-20 18:00:00 +0800
+title: "W3C Launches the Web Machine Learning Working Group"
+date: 2021-04-20 18:00:00 +0800
 author: Dominique Hazaël-Massieux
 avatar: https://avatars.githubusercontent.com/u/216410?v=4
 categories: blog
@@ -10,7 +10,7 @@ toc: true
 
 ## Introduction
 
-Machine Learning (ML) is a branch of Artificial Intelligence. A subfield of ML called Deep Learning with its various neural network architectures enables new compelling user experiences for web applications. [Use cases](https://webmachinelearning.github.io/webnn/#usecases) range from improved video conferencing to accessibility-improving features, with potential improved privacy over cloud-based solutions. Enabling these use cases and more is the focus of the newly launched [Web Machine Learning Working Group](https://www.w3.org/groups/wg/webmachinelearning").
+Machine Learning (ML) is a branch of Artificial Intelligence. A subfield of ML called Deep Learning with its various neural network architectures enables new compelling user experiences for web applications. [Use cases](https://www.w3.org/TR/webnn/#usecases) range from improved video conferencing to accessibility-improving features, with potential improved privacy over cloud-based solutions. Enabling these use cases and more is the focus of the newly launched [Web Machine Learning Working Group](https://www.w3.org/groups/wg/webmachinelearning").
 
 ![WebNN Logo]({{ '/assets/images/webml-logo-sm.png' | relative_url }})
 
@@ -22,32 +22,26 @@ While some of these use cases can be implemented in-device in a constrained mann
 
 With these design goals in mind, a [W3C Community Group](https://www.w3.org/community/webmachinelearning/) started incubating work in 2018 for a possible Web Neural Network API, in response to encouraging feedback from a [TPAC breakout session](https://www.w3.org/2018/10/24-webmachinelearning-minutes.html). Starting October 2018, this Community Group identified key use cases working with diverse participants including major browser vendors, key ML JS frameworks, interested hardware vendors, and web developers. After identification of the key use cases, the group decomposed the key use cases into requirements and started drafting the [Web Neural Network API specification](https://webmachinelearning.github.io/webnn) in mid-2019. The aim of this use case-driven design process was to put user needs first.
 
-### Quotes 
+### Quotes
 
 > “Having access to the native ML accelerators, machine learning frameworks such as TensorFlow.js can greatly improve model execution efficiency and truly democratize ML for web developers.”
 >
 > – Ping Yu, TLM for [TensorFlow.js](https://www.tensorflow.org/js") at Google
 
-> “The [early empirical results from the Web Neural Network API implementations](https://www.w3.org/2020/06/machine-learning-workshop/talks/access_purpose_built_ml_hardware_with_web_neural_network_api.html#slide-10) demonstrate tremendous power &amp; performance improvements of the Web AI workloads. Through access to the full native AI capabilities of the modern heterogeneous hardware, the Web Neural Network API enables a whole new transformative class of intelligent user experiences on the Open Web Platform across a variety of hardware, software, and device types.” 
-> 
+> “The [early empirical results from the Web Neural Network API implementations](https://www.w3.org/2020/06/machine-learning-workshop/talks/access_purpose_built_ml_hardware_with_web_neural_network_api.html#slide-10) demonstrate tremendous power &amp; performance improvements of the Web AI workloads. Through access to the full native AI capabilities of the modern heterogeneous hardware, the Web Neural Network API enables a whole new transformative class of intelligent user experiences on the Open Web Platform across a variety of hardware, software, and device types.”
+>
 > &#8211; Ningxin Hu, Principal Engineer, Web Platform Engineering at Intel
 
 W3C organized a [workshop on Web and Machine Learning](https://www.w3.org/2020/06/machine-learning-workshop) over the course of August and September 2020. This workshop brought together web platform and machine learning practitioners to survey the broader intersection of Web technologies and Machine Learning, and one of the [conclusions of the Workshop](https://www.w3.org/2020/06/machine-learning-workshop/report.html) was to propose that [a new W3C Working Group should be formed](https://lists.w3.org/Archives/Public/public-new-work/2021Feb/0007.html) to standardize the Web Neural Network API, graduating from its incubation stage. As of 2021, the Community Group continues its incubation function working in parallel with the Working Group, similarly to e.g. W3C’s WebAssembly and WebGPU efforts.
 
 > “The Web Neural Network API is a very important step toward the future of the Intelligent Web where AI is infused into the user&#8217;s daily web experiences. With the current advances and the pace of innovations in the AI hardware landscape, it&#8217;ll help connect those experiences from the clouds and make them personal to the users through seamless native hardware performance on the edge devices across the entire web. That&#8217;s the future worth dreaming about!”
-> 
+>
 > &#8211; [Chai Chaoweeraprasit](https://www.w3.org/2020/06/machine-learning-workshop/talks/accelerated_graphics_and_compute_api_for_machine_learning_directml.html), Principal Engineering Lead, Machine Learning and Compute Platform at Microsoft
 
 The [Web Machine Learning Working Group](https://www.w3.org/groups/wg/webmachinelearning) plans to publish the First Public Working Draft of the Web Neural Network API during the first half of 2021 and welcomes new participants from the diverse W3C community to take part in helping identify new use cases, documenting ethical risks and their mitigations, contributing to technical work, conducting wide reviews in privacy, security, accessibility, and other important areas to ensure the perspectives of the diverse web community are heard. &#8211; which given some of the ethical impact of Machine Learning algorithms will be particularly critical to the work of the group. Join us!
 
 We would like to thank all the W3C Community Group and W3C workshop participants for their contributions that have helped shape this work, and W3C for providing a venue to advance this cross-industry effort toward wide adoption.
 
-*This post is co-authored by Anssi Kostiainen (Working Group Chair), Ningxin Hu and Chai Chaoweeraprasit (Web Neural Network API Editors), and Ping Yu (TensorFlow.js Core team).*
+_This post is co-authored by Anssi Kostiainen (Working Group Chair), Ningxin Hu and Chai Chaoweeraprasit (Web Neural Network API Editors), and Ping Yu (TensorFlow.js Core team)._
 
-*Source: [W3C Launches the Web Machine Learning Working Group](https://www.w3.org/blog/2021/04/w3c-launches-the-web-machine-learning-working-group/)*
-
-
-
-			
-
-
+_Source: [W3C Launches the Web Machine Learning Working Group](https://www.w3.org/blog/2021/04/w3c-launches-the-web-machine-learning-working-group/)_

--- a/_posts/2021-04-27-progressing-web-machine-learning-innovations-to-w3c-standards-track.md
+++ b/_posts/2021-04-27-progressing-web-machine-learning-innovations-to-w3c-standards-track.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title:  "Progressing Web Machine Learning Innovations to W3C Standards Track"
-date:   2021-04-27 18:00:00 +0800
+title: "Progressing Web Machine Learning Innovations to W3C Standards Track"
+date: 2021-04-27 18:00:00 +0800
 author: Anssi Kostiainen
 avatar: https://avatars.githubusercontent.com/u/765510?s=120&v=4
 categories: blog
@@ -9,7 +9,7 @@ categories: blog
 
 🌱 This [W3C Community Group](https://www.w3.org/community/webmachinelearning/) started incubating work in 2018 for a possible Web Neural Network API, in response to encouraging feedback from a [TPAC breakout session](https://www.w3.org/2018/10/24-webmachinelearning-minutes.html). Starting October 2018, this Community Group identified key use cases working with diverse participants including major browser vendors, key ML JS frameworks, interested hardware vendors, web developers, and started drafting the Web Neural Network API specification.
 
-🚀 Following the two-year incubation period in this Community Group, the W3C has launched the [Web Machine Learning Working Group](https://www.w3.org/groups/wg/webmachinelearning) to standardize the [Web Neural Network API](https://webmachinelearning.github.io/webnn/), now graduating from its incubation stage. This Community Group continues its incubation function for new machine learning capabilities working in parallel with the newly formed Working Group, similarly to e.g. W3C’s WebAssembly and WebGPU efforts.
+🚀 Following the two-year incubation period in this Community Group, the W3C has launched the [Web Machine Learning Working Group](https://www.w3.org/groups/wg/webmachinelearning) to standardize the [Web Neural Network API](https://www.w3.org/TR/webnn/), now graduating from its incubation stage. This Community Group continues its incubation function for new machine learning capabilities working in parallel with the newly formed Working Group, similarly to e.g. W3C’s WebAssembly and WebGPU efforts.
 
 <!-- more -->
 
@@ -19,6 +19,3 @@ categories: blog
 
 Anssi Kostiainen<br>
 Web Machine Learning Community Group Chair
-			
-
-


### PR DESCRIPTION
As the follow up of https://github.com/webmachinelearning/webmachinelearning.github.io/pull/36, updated all the spec link to latest published version.

@anssiko @Honry PTAL