### PR TITLE
Implementation status update for 60 v1 ops

### DIFF
--- a/assets/json/webnn_status.json
+++ b/assets/json/webnn_status.json
@@ -1,0 +1,1701 @@
+{
+  "impl_status": [
+    {
+      "op": "batchNormalization",
+      "op_id": "batchnorm",
+      "version": "v1",
+      "wpt": "batch_normalization",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "BATCH_NORMALIZATION"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        ""
+      ],
+      "ort_progress": 2,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "clamp",
+      "op_id": "clamp",
+      "version": "v1",
+      "wpt": "clamp",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "clamp"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_CLIP"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "ReluN1To1"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Clip"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "concat",
+      "op_id": "concat",
+      "version": "v1",
+      "wpt": "concat",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "concatenate2",
+        "concatenate3",
+        "concatenate4"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M113",
+      "dml_op": [
+        "JOIN"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Concatenation"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Concat"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "conv2d",
+      "op_id": "conv2d",
+      "version": "v1",
+      "wpt": "conv2d",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "convolution_2d",
+        "depthwise_convolution_2d"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "CONVOLUTION"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Conv2d",
+        "DepthwiseConv2d"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Conv"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "convTranspose2d",
+      "op_id": "convtranspose2d",
+      "version": "v1",
+      "wpt": "conv_transpose2d",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "deconvolution_2d"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M113",
+      "dml_op": [
+        "CONVOLUTION"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "TransposeConv",
+        "Convolution2DTransposeBias"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "ConvTranspose"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / add",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "add2"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_ADD"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Add"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Add"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / sub",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "subtract"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_SUBTRACT"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Sub"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Sub"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / mul",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "multiply2"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_MULTIPLY"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Mul"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Mul"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / div",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "divide"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_DIVIDE"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Div"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Div"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / max",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "maximum2"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_MAX"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "Maximum"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Max"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / min",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "minimum2"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ELEMENT_WISE_MIN"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Minimum"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Min"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise binary / pow",
+      "op_id": "binary",
+      "version": "v1",
+      "wpt": "elementwise_binary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "square",
+        "square_root"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "ELEMENT_WISE_POW"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Sqrt",
+        "Square"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Pow"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / abs",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "abs"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "ELEMENT_WISE_ABS"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "Abs"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Abs"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / ceil",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "ceiling"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "ELEMENT_WISE_CEIL"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Ceil"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Ceil"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / cos",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ELEMENT_WISE_COS"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Cos"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / exp",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ELEMENT_WISE_EXP"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Exp"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / floor",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "floor"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "ELEMENT_WISE_FLOOR"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Floor"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Floor"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / log",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ELEMENT_WISE_LOG"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Log"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / neg",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "negate"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "ELEMENT_WISE_NEGATE"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "Neg"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Neg"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / sin",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ELEMENT_WISE_SIN"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Sin"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "element-wise unary / tan",
+      "op_id": "unary",
+      "version": "v1",
+      "wpt": "elementwise_unary",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ELEMENT_WISE_TAN"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Tan"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "elu",
+      "op_id": "elu",
+      "version": "v1",
+      "wpt": "elu",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "elu"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M115",
+      "dml_op": [
+        "ACTIVATION_ELU"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "Elu"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Elu"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "gemm",
+      "op_id": "gemm",
+      "version": "v1",
+      "wpt": "gemm",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "fully_connected"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "GEMM"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "FullyConnected"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Gemm"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "gru",
+      "op_id": "gru",
+      "version": "v1",
+      "wpt": "",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "GRU"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        ""
+      ],
+      "ort_progress": 2,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "gruCell",
+      "op_id": "grucell",
+      "version": "v1",
+      "wpt": "",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "GRU"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        ""
+      ],
+      "ort_progress": 2,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "hardSigmoid",
+      "op_id": "hard-sigmoid",
+      "version": "v1",
+      "wpt": "hard_sigmoid",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ACTIVATION_HARD_SIGMOID"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "HardSigmoid"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "hardSwish",
+      "op_id": "hard-swish",
+      "version": "v1",
+      "wpt": "hard_swish",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "hardswish"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "Map to other op"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "HardSwish"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "HardSwish"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "instanceNormalization",
+      "op_id": "instancenorm",
+      "version": "v1",
+      "wpt": "",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "MEAN_VARIANCE_NORMALIZATION1"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "InstanceNormalization"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "leakyRelu",
+      "op_id": "leakyrelu",
+      "version": "v1",
+      "wpt": "leaky_relu",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "leaky_relu"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M113",
+      "dml_op": [
+        "ACTIVATION_LEAKY_RELU"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "LeakyRelu"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "LeakyRelu"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "linear",
+      "op_id": "linear",
+      "version": "v1",
+      "wpt": "linear",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ACTIVATION_LINEAR"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        ""
+      ],
+      "ort_progress": 2,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "lstm",
+      "op_id": "lstm",
+      "version": "v1",
+      "wpt": "",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "LSTM"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        ""
+      ],
+      "ort_progress": 2,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "lstmCell",
+      "op_id": "lstmcell",
+      "version": "v1",
+      "wpt": "",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "LSTM"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        ""
+      ],
+      "ort_progress": 2,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "matmul",
+      "op_id": "matmul",
+      "version": "v1",
+      "wpt": "matmul",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "GEMM"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "MatMul"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "pad",
+      "op_id": "pad",
+      "version": "v1",
+      "wpt": "pad",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "static_constant_pad"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M114",
+      "dml_op": [
+        "FILL_VALUE_SEQUENCE"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Pad"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Pad"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "pooling / averagePool2d",
+      "op_id": "pool2d",
+      "version": "v1",
+      "wpt": "pooling",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "average_pooling_2d",
+        "global_average_pooling_2d"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "AVERAGE_POOLING"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "AveragePool2d",
+        "Mean"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "AveragePool",
+        "GlobalAveragePool"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "pooling / l2Pool2d",
+      "op_id": "pool2d",
+      "version": "v1",
+      "wpt": "pooling",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "LP_POOLING"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "LpPool",
+        "GlobalLpPool"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "",
+      "notes": ""
+    },
+    {
+      "op": "pooling / maxPool2d",
+      "op_id": "pool2d",
+      "version": "v1",
+      "wpt": "pooling",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "max_pooling_2d"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "MAX_POOLING2"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "MaxPool2d"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "GlobalMaxPool",
+        "MaxPool"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "prelu",
+      "op_id": "prelu",
+      "version": "v1",
+      "wpt": "prelu",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "prelu"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M115",
+      "dml_op": [
+        "ACTIVATION_PARAMETERIZED_RELU"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        "Prelu"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "PRelu"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceL1",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_L1"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceL1"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceL2",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_L2"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceL2"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceLogSum",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_LOG_SUM"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceLogSum"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceLogSumExp",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_LOG_SUM_EXP"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceLogSumExp"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceMax",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_MAX"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceMax"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceMean",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "static_mean"
+      ],
+      "xnnpack_progress": 3,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "REDUCE_FUNCTION_AVERAGE"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceMean"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceMin",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_MIN"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceMin"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceProduct",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_MULTIPLY"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceProd"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceSum",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "global_sum_pooling_1d",
+        "global_sum_pooling_2d"
+      ],
+      "xnnpack_progress": 3,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "REDUCE_FUNCTION_SUM"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceSum"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reduction / reduceSumSquare",
+      "op_id": "reduce",
+      "version": "v1",
+      "wpt": "reduction",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "REDUCE_FUNCTION_SUM_SQUARE"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "ReduceSumSquare"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "relu",
+      "op_id": "relu",
+      "version": "v1",
+      "wpt": "relu",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "clamp"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ACTIVATION_RELU"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Relu"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Relu"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "resample2d",
+      "op_id": "resample2d",
+      "version": "v1",
+      "wpt": "",
+      "wpt_progress": 3,
+      "xnnpack_op": [
+        "static_resize_bilinear_2d"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "RESAMPLE"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "ResizeBilinear"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Resize"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "reshape",
+      "op_id": "reshape",
+      "version": "v1",
+      "wpt": "reshape",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "static_reshape"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "Supported by tensor strides"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Reshape"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Reshape"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "sigmoid",
+      "op_id": "sigmoid",
+      "version": "v1",
+      "wpt": "sigmoid",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "sigmoid"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ACTIVATION_SIGMOID"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Logistic"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Sigmoid"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "slice",
+      "op_id": "slice",
+      "version": "v1",
+      "wpt": "slice",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "static_slice"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "SLICE"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Slice",
+        "StridedSlice"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Slice"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "softmax",
+      "op_id": "softmax",
+      "version": "v1",
+      "wpt": "softmax",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "softmax"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M112",
+      "dml_op": [
+        "ACTIVATION_SOFTMAX"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Softmax"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Softmax"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "softplus",
+      "op_id": "softplus",
+      "version": "v1",
+      "wpt": "softplus",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ACTIVATION_SOFTPLUS"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Softplus"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "softsign",
+      "op_id": "softsign",
+      "version": "v1",
+      "wpt": "softsign",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "ACTIVATION_SOFTSIGN"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Softsign"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "split",
+      "op_id": "split",
+      "version": "v1",
+      "wpt": "split",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "even_split2",
+        "even_split3",
+        "even_split4",
+        "static_slice (uneven split)"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "SPLIT"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Split"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Split"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "squeeze",
+      "op_id": "squeeze",
+      "version": "v1",
+      "wpt": "squeeze",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        ""
+      ],
+      "xnnpack_progress": 2,
+      "xnnpack_chromium_version_added": "",
+      "dml_op": [
+        "Supported by tensor strides"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Squeeze"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "tanh",
+      "op_id": "tanh",
+      "version": "v1",
+      "wpt": "tanh",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "tanh"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M116",
+      "dml_op": [
+        "ACTIVATION_TANH"
+      ],
+      "dml_progress": 2,
+      "dml_chromium_version_added": "",
+      "tflite_op": [
+        ""
+      ],
+      "tflite_progress": 2,
+      "tflite_version_added": "",
+      "ort_op": [
+        "Tanh"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    },
+    {
+      "op": "transpose",
+      "op_id": "transpose",
+      "version": "v1",
+      "wpt": "transpose",
+      "wpt_progress": 4,
+      "xnnpack_op": [
+        "static_transpose"
+      ],
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M113",
+      "dml_op": [
+        "Supported by tensor strides"
+      ],
+      "dml_progress": 3,
+      "dml_chromium_version_added": "Chromium fork",
+      "tflite_op": [
+        "Transpose"
+      ],
+      "tflite_progress": 3,
+      "tflite_version_added": "TensorFlow fork",
+      "ort_op": [
+        "Transpose"
+      ],
+      "ort_progress": 4,
+      "ort_version_added": "main",
+      "notes": ""
+    }
+  ]
+}

--- a/webnn-status.md
+++ b/webnn-status.md
@@ -10,6 +10,7 @@ permalink: /webnn-status/
  margin: 4px 0;
  transform: none;
  display: inline-block;
+ min-width: 24px;
 }
 
 .post .onnxrt img {
@@ -20,29 +21,60 @@ permalink: /webnn-status/
  width: 102px;
 }
 
-.post-content tbody td {
- padding: 4px 48px;
- vertical-align: middle;
+.post table {
+  font-size: 0.8rem;
 }
 
-.post-content tbody td br {
-  height:  0px;
-  display: none;
+.post table tr td {
+  text-align: left;
+}
+
+.post table tr td:nth-child(1), 
+.post table tr td:nth-child(2),
+.post table tr td:nth-child(4), 
+.post table tr td:nth-child(6),
+.post table tr td:nth-child(8), 
+.post table tr td:nth-child(10) {
+  text-align: center;
+}
+
+.post table td {
+  padding: 4px 6px;
+  vertical-align: middle;
+}
+
+.post table th {
+  padding: 6px 6px;
 }
 
 .impl_status {
    text-align: center;
    display: grid; 
-   grid-template-columns: 1fr 1fr 1fr;
+   grid-template-columns: 1fr 1fr 1fr 1fr;
    gap: 0px;
    border: 1px solid #dfe2e5;
-   padding: 10px;
+   padding: 12px;
    font-size: 0.9em;
 }
 
-.impl_status .title, .post-content table .title {
-  font-weight: 400;
+.impl_status .title {
   font-size: 1rem;
+  line-height: 1rem;
+}
+.post-content table th {
+  font-weight: 400;
+  font-size: 0.9rem;
+  line-height: 0.9rem;
+}
+
+.post svg#w3 {
+  transform: none;
+  height: 36px;
+  width: 72px;
+}
+
+sup {
+  font-size: 0.7rem;
 }
 
 .impl_status .title {
@@ -54,62 +86,107 @@ permalink: /webnn-status/
 }
 </style>
 
-| <br><span class="title">![W3C](https://www.w3.org/StyleSheets/TR/2021/logos/W3C)<br>[WebNN Spec](https://www.w3.org/TR/webnn/)</span> | <br><span class="title">Web Platform<br>Tests</span> | <span class="title">XNNPack/CPU backend</span> <sup>[1]</sup><br/>![Chrome Dev](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-dev/chrome-dev_24x24.png) ![Edge Canary](https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_24x24.png) <sup>[4]</sup><br/> ![Windows](https://wpt.fyi/static/win.svg) ![Linux](https://wpt.fyi/static/linux.svg) | ![TensorFlow Lite](https://www.gstatic.com/devrel-devsite/prod/v8ec4d0a037302c47ae529ad4e3f06c9e782b3a31a381294b5a70403547dc6b12/tensorflow/images/lockup.svg) Lite  <span class="tflite"></span><br>for TensorFlow.js<br/><span class="title">External Delegate</span> <sup>[2]</sup> | ![ONNX Runtime Web](https://onnxruntime.ai/images/svg/ONNX-Runtime-logo.svg) <span class="onnxrt"></span><br/><span class="title">Execution Provider</span> <sup>[3]</sup> | 
-| -- | -- | -- | -- | -- |
-| <span class="spec">[clamp](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-clamp)</span> | [📈](https://wpt.fyi/results/webnn/clamp.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/clamp.https.any.js) | <span class="x_s">✅</span> clamp | <span class="ed_s">✅</span> ReluN1To1 | <span class="ep_s">✅</span> Clip |
-|  |  | ✅ Relu6 |  |  |
-| <br><span class="spec">[concat](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-concat)</span> | [📈](https://wpt.fyi/results/webnn/concat.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/concat.https.any.js) | <span class="x_s">✅</span> concatenate2 | <br><span class="ed_s">✅</span> Concatenation | <br><span class="ep_s">✅</span> Concat |
-|  |  | ✅ concatenate3 |  |  |
-|  |  | ✅ concatenate4 |  |  |
-| <span class="spec">[conv2d](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d)</span> | [📈](https://wpt.fyi/results/webnn/conv2d.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/conv2d.https.any.js) | <span class="x_s">✅</span> convolution_2d | <span class="ed_s">✅</span> Conv2d | <span class="ep_s">✅</span> Conv |
-|  |  |  | ✅ DepthwiseConv2d |  |
-| <span class="spec">[convTranspose2d](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d)</span> | [📈](https://wpt.fyi/results/webnn/conv_transpose2d.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/conv_transpose2d.https.any.js) | <span class="x_s">✅</span> deconvolution_2d | <span class="ed_s">✅</span> TransposeConv | <span class="ep_s">✅</span> ConvTranspose |
-|  |  |  | ✅ Convolution2DTransposeBias |  |
-| <span class="spec">[add <sup>element-wise binary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-binary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_binary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_binary.https.any.js) | <span class="x_s">✅</span> add2 | <span class="ed_s">✅</span> Add | <span class="ep_s">✅</span> Add |
-| <span class="spec">[sub <sup>element-wise binary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-binary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_binary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_binary.https.any.js) | <span class="x_s">✅</span> subtract | <span class="ed_s">✅</span> Sub | <span class="ep_s">✅</span> Sub |
-| <span class="spec">[mul <sup>element-wise binary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-binary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_binary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_binary.https.any.js) | <span class="x_s">✅</span> multiply2 | <span class="ed_s">✅</span> Mul | <span class="ep_s">✅</span> Mul |
-| <span class="spec">[div <sup>element-wise binary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-binary)</span> | [📈](https://wpt.fyi/results/webnn/clamp.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_binary.https.any.js) | <span class="x_s">✅</span> divide | <span class="ed_s">✅</span> Div | <span class="ep_s">✅</span> Div |
-| <span class="spec">[max <sup>element-wise binary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-binary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_binary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_binary.https.any.js) | <span class="x_s">✅</span> maximum2 | <span class="ed_s">✅</span> Maximum | <span class="ep_wip">🚀</span> Max |
-| <span class="spec">[min <sup>element-wise binary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-binary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_binary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_binary.https.any.js) | <span class="x_s">✅</span> minimum2 | <span class="ed_s">✅</span> Minimum | <span class="ep_wip">🚀</span> Min |
-| <span class="spec">[abs <sup>element-wise unary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-unary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_unary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_unary.https.any.js) | <span class="x_s">✅</span> abs | <span class="ed_s">✅ Abs</span> | <span class="ep_wip">🚀</span> Abs |
-| <span class="spec">[ceil <sup>element-wise unary</sup>](https://www.w3.org/TR/webnn/api-mlgraphbuilder-unary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_unary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_unary.https.any.js) | <span class="x_s">✅</span> ceiling | <span class="ed_s">✅ Ceil</span> | <span class="ep_s">✅</span> Ceil |
-| <span class="spec">[floor <sup>element-wise unary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-unary)</span> |[📈](https://wpt.fyi/results/webnn/elementwise_unary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_unary.https.any.js) | <span class="x_s">✅</span> floor | <span class="ed_s">✅ Floor</span> | <span class="ep_s">✅</span> Floor |
-| <span class="spec">[neg <sup>element-wise unary</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-unary)</span> | [📈](https://wpt.fyi/results/webnn/elementwise_unary.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elementwise_unary.https.any.js) | <span class="x_s">✅</span> negate | <span class="ed_s">✅ Neg</span> | <span class="ep_wip">🚀</span> Neg |
-| <span class="spec">[elu](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-elu)</span> | [📈](https://wpt.fyi/results/webnn/elu.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/elu.https.any.js) | <span class="x_s">✅</span> elu | <span class="ed_s">✅</span> Elu | <span class="ep_wip">🚀</span> Elu |
-| <span class="spec">[gemm](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gemm)</span> | [📈](https://wpt.fyi/results/webnn/gemm.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/gemm.https.any.js) | <span class="x_s">✅</span> fully_connected | <span class="ed_s">✅</span> FullyConnected | <span class="ep_s">✅</span> Gemm |
-| <span class="spec">[hardSwish](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-swish)</span> | [📈](https://wpt.fyi/results/webnn/hard_swish.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/hard_swish.https.any.js) | <span class="x_s">✅</span> hardswish | <span class="ed_s">✅</span> HardSwish | <span class="ep_wip">🚀</span> HardSwish |
-| <span class="spec">[leakyRelu](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-leakyrelu)</span> | [📈](https://wpt.fyi/results/webnn/leaky_relu.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/leaky_relu.https.any.js) | <span class="x_s">✅</span> leaky_relu | <span class="ed_s">✅</span> LeakyRelu | <span class="ep_s">✅</span> LeakyRelu |
-| <span class="spec">[pad](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pad)</span> | [📈](https://wpt.fyi/results/webnn/pad.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/pad.https.any.js) | <span class="x_s">✅</span> static_constant_pad | <span class="ed_s">✅</span> Pad | <span class="ep_wip">🚀</span> Pad |
-| <span class="spec">[averagePool2d <sup>pooling</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d)</span> | [📈](https://wpt.fyi/results/webnn/pooling.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/pooling.https.any.js) | <span class="x_s">✅</span> average_pooling_2d | <span class="ed_s">✅</span> AveragePool2d | <span class="ep_s">✅</span> GlobalAveragePool |
-|  |  |  | ✅ Mean | ✅ AveragePool |
-| <span class="spec">[maxPool2d <sup>pooling</sup>](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d)</span> | [📈](https://wpt.fyi/results/webnn/pooling.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/pooling.https.any.js) | <span class="x_s">✅</span> max_pooling_2d | <span class="ed_s">✅</span> MaxPool2d | <span class="ep_s">✅</span> GlobalMaxPool |
-|  |  |  |  | ✅ MaxPool |
-| <span class="spec">[prelu](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-prelu)</span> | [📈](https://wpt.fyi/results/webnn/prelu.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/prelu.https.any.js) | <span class="x_s">✅</span> prelu | <span class="ed_s">✅</span> Prelu | <span class="ep_wip">🚀</span> Prelu |
-| <span class="spec">[relu](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-relu)</span> | [📈](https://wpt.fyi/results/webnn/relu.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/relu.https.any.js) | <span class="x_s">✅</span> clamp | <span class="ed_s">✅</span> Relu | <span class="ep_s">✅</span> Relu |
-| <span class="spec">[resample2d](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-resample2d)</span> | <span class="wpt_wip">🚀🚀</span> | <span class="x_s">✅</span> static_resize_bilinear_2d | <span class="ed_s">✅</span> ResizeBilinear | <span class="ep_s">✅</span> Resize |
-| <span class="spec">[reshape](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-reshape)</span> | [📈](https://wpt.fyi/results/webnn/reshape.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/reshape.https.any.js) | <span class="x_s">✅</span> static_reshape | <span class="ed_s">✅</span> Reshape | <span class="ep_s">✅</span> Reshape |
-| <span class="spec">[sigmoid](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-sigmoid)</span> | [📈](https://wpt.fyi/results/webnn/sigmoid.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/sigmoid.https.any.js) | <span class="x_s">✅</span> sigmoid | <span class="ed_s">✅</span> Logistic | <span class="ep_s">✅</span> Sigmoid |
-| <br><br><span class="spec">[split](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-split)</span> | [📈](https://wpt.fyi/results/webnn/split.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/split.https.any.js) | <span class="x_s">✅</span> even_split2 | <br><br><span class="ed_s">✅</span> Split | <br><br><span class="ep_s">✅</span> Split |
-|  |  | ✅ even_split3 |  |  |
-|  |  | ✅ even_split4 |  |  |
-|  |  | ✅ static_slice (uneven split) |  |  |
-| <span class="spec">[slice](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-slice)</span> | [📈](https://wpt.fyi/results/webnn/slice.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/slice.https.any.js) | <span class="x_s">✅</span> static_slice | <span class="ed_s">✅</span> Slice | <span class="ep_s">✅</span> Slice |
-|  |  |  | ✅ StridedSlice |  |
-| <span class="spec">[softmax](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softmax)</span> | [📈](https://wpt.fyi/results/webnn/softmax.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/softmax.https.any.js) | <span class="x_s">✅</span> softmax | <span class="ed_s">✅</span> Softmax | <span class="ep_s">✅</span> Softmax | 
-| <span class="spec">[transpose](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-transpose)</span> | [📈](https://wpt.fyi/results/webnn/transpose.https.any.html?label=master&label=experimental) [<span class="wpt_s">🧪</span>](https://github.com/web-platform-tests/wpt/blob/master/webnn/transpose.https.any.js) | <span class="x_s">✅</span> static_transpose | <span class="ed_s">✅</span> Transpose | <span class="ep_s">✅</span> Transpose |
-| <span id="spec_total" class="title"></span> | <span id="wpt_total" class="title"></span> | <span id="x_total" class="title"></span> | <span id="ed_total" class="title"></span> | <span id="ep_total" class="title"></span> |
+<table>
+  <thead>
+    <tr class="title">
+      <th rowspan="3">
+        <a href="https://www.w3.org/TR/webnn/">
+          <svg id="w3" x="0px" y="0px" viewBox="0 0 357.5 287" style="enable-background:new 0 0 357.5 287;">
+            <style type="text/css">
+              .st0 {
+                fill: #005A9C;
+              }
+
+              .st1 {
+                fill: #221B0A;
+              }
+            </style>
+            <g>
+              <path class="st0" d="M118.4,76.6l24.2,82.4l24.2-82.4h17.5l-40.1,135.3h-1.7l-25.1-83.8l-25.1,83.8h-1.7L50.8,76.6h17.5L92.5,159
+                    l16.4-55.5l-8-26.9L118.4,76.6L118.4,76.6z" />
+              <path class="st0" d="M234.2,168.5c0,12.3-3.3,22.6-9.8,30.9c-6.5,8.3-15,12.5-25.3,12.5c-7.8,0-14.6-2.5-20.4-7.4
+                    c-5.8-5-10.1-11.7-12.9-20.1l13.7-5.7c2,5.1,4.7,9.2,7.9,12.1c3.3,2.9,7.1,4.4,11.6,4.4c4.7,0,8.6-2.6,11.9-7.9
+                    c3.2-5.2,4.8-11.5,4.8-18.9c0-8.1-1.7-14.4-5.2-18.9c-4-5.2-10.3-7.9-18.9-7.9h-6.7v-8l23.4-40.4h-28.2l-7.9,13.4h-5V76.6h65.1v8.2
+                    l-24.7,42.6c8.7,2.8,15.3,7.9,19.7,15.2C232,149.9,234.2,158.6,234.2,168.5L234.2,168.5z" />
+              <path class="st1"
+                d="M302.2,75.9l2.8,17.3l-10.1,19.2c0,0-3.9-8.2-10.3-12.7c-5.4-3.8-8.9-4.6-14.4-3.5
+                    c-7.1,1.5-15.1,9.9-18.6,20.3c-4.2,12.5-4.2,18.5-4.4,24c-0.2,8.9,1.2,14.1,1.2,14.1s-6.1-11.3-6-27.8c0-11.8,1.9-22.5,7.4-33.1
+                    c4.8-9.3,11.9-14.9,18.3-15.5c6.6-0.7,11.7,2.5,15.7,5.9c4.2,3.6,8.5,11.4,8.5,11.4L302.2,75.9L302.2,75.9z" />
+              <path class="st1" d="M303.4,173.6c0,0-4.4,7.9-7.2,11c-2.8,3.1-7.7,8.5-13.8,11.2c-6.1,2.7-9.3,3.2-15.4,2.6
+                    c-6-0.6-11.7-4.1-13.6-5.5c-2-1.4-7-5.8-9.8-9.7c-2.9-4-7.3-12-7.3-12s2.5,8,4,11.4c0.9,2,3.6,8,7.5,13.2
+                    c3.6,4.9,10.7,13.3,21.4,15.1c10.7,1.9,18.1-2.9,19.9-4.1c1.8-1.2,5.7-4.4,8.1-7c2.5-2.7,4.9-6.2,6.3-8.2c1-1.5,2.6-4.6,2.6-4.6
+                    L303.4,173.6L303.4,173.6z" />
+            </g>
+          </svg>
+          <br />WebNN Spec
+        </a>
+      </th>
+      <th rowspan="3">Web Platform<br />Tests</th>
+      <th colspan="4">
+        Chromium Implementation
+      </th>
+      <th colspan="4">JavaScript ML Frameworks Integration</th>
+    </tr>
+    <tr class="title">
+      <th colspan="2"><img src="https://wpt.fyi/static/win.svg"> <img
+          src="https://wpt.fyi/static/linux.svg"><br />XNNPack/CPU
+        backend
+        <sup>1</sup>
+      </th>
+      <th colspan="2"><img src="https://wpt.fyi/static/win.svg"><br />DirectML/GPU backend <sup>2</sup>
+      </th>
+      <th colspan="2"><img
+          src="https://www.gstatic.com/devrel-devsite/prod/v8ec4d0a037302c47ae529ad4e3f06c9e782b3a31a381294b5a70403547dc6b12/tensorflow/images/lockup.svg">
+        Lite for TF.js<br />External Delegate <sup>3</sup></th>
+      <th colspan="2"><img src="https://onnxruntime.ai/images/svg/ONNX-Runtime-logo.svg" /><br />Execution Provider
+        <sup>4</sup>
+      </th>
+    </tr>
+    <tr class="title">
+      <th>Operations
+      </th>
+      <th>
+        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-dev/chrome-dev_128x128.png" />
+        <img
+          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>5</sup>
+      </th>
+      <th>Operations</th>
+      <th>
+        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-dev/chrome-dev_128x128.png" />
+        <img
+          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>5</sup>
+      </th>
+      <th>Operations
+      </th>
+      <th>Delegate Version
+      </th>
+      <th>Operations
+      </th>
+      <th>EP Version
+      </th>
+    </tr>
+  </thead>
+  <tbody id="ops"></tbody>
+</table>
 
 <div class="impl_status">
     <div class="title">XNNPack/CPU backend</div>
-    <div class="title">TensorFlow Lite External Delegate</div>
-    <div class="title">ONNX Runtime Execution Provider</div>
+    <div class="title">DirectML/GPU backend</div>
+    <div class="title">TensorFlow.js/TFLite<br/>External Delegate</div>
+    <div class="title">ONNX Runtime Web<br/>Execution Provider</div>
     <div>
-        <div>✅ Supported (<span id="supported"></span>)</div>
-        <div>⏳ Partly Implemented (<span id="partlyimplemented"></span>)</div>
-        <div>🚀 Work in Progress (<span id="workinprogress"></span>)</div>
+        <div>✅ Supported (<span id="x_supported"></span>)</div>
+        <div>⏳ Partly Implemented (<span id="x_partlyimplemented"></span>)</div>
+        <div>🚀 Work in Progress (<span id="x_workinprogress"></span>)</div>
         <div>❌ Not Supported</div>
     </div>
-        <div>
+    <div>
+        <div>✅ Supported (<span id="dml_supported"></span>)</div>
+        <div>⏳ Partly Implemented (<span id="dml_partlyimplemented"></span>)</div>
+        <div>🚀 Work in Progress (<span id="dml_workinprogress"></span>)</div>
+        <div>❌ Not Supported</div>
+    </div>
+    <div>
         <div>✅ Supported (<span id="ed_supported"></span>)</div>
         <div>⏳ Partly Implemented (<span id="ed_partlyimplemented"></span>)</div>
         <div>🚀 Work in Progress (<span id="ed_workinprogress"></span>)</div>
@@ -125,10 +202,11 @@ permalink: /webnn-status/
 
 The total number of WebNN v1 ops is 60. This table currently lists ops that are implemented or WIP by multiple backends.
 
-<sup>[1]</sup> XNNPack node definition in [`xnn_define_*`](https://github.com/google/XNNPACK/blob/master/include/xnnpack.h)<br>
-<sup>[2]</sup> TensorFlow Lite built-in operators [`kTfLiteBuiltin*`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc)<br>
-<sup>[3]</sup> ONNX [`Operator Schemas`](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [`WebNN EP Helper`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/webnn/builders/helper.h)<br>
-<sup>[4]</sup> Enabled in [Google Chrome Dev 115](https://www.google.com/chrome/dev/) and [Microsoft Edge Canary 115](https://www.microsoftedgeinsider.com/en-us/download/canary) channels
+<sup>[1]</sup> XNNPack node definition in [`xnn_define_*`](https://github.com/google/XNNPACK/blob/master/include/xnnpack.h)<br/>
+<sup>[2]</sup> [DirectML](https://learn.microsoft.com/en-us/windows/win32/api/_directml/) API<br/>
+<sup>[3]</sup> TensorFlow Lite built-in operators [`kTfLiteBuiltin*`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc)<br/>
+<sup>[4]</sup> ONNX [`Operator Schemas`](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [`WebNN EP Helper`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/webnn/builders/helper.h)<br/>
+<sup>[5]</sup> Currently enabled in [Google Chrome Dev](https://www.google.com/chrome/dev/) and [Microsoft Edge Canary](https://www.microsoftedgeinsider.com/en-us/download/canary) channels with #enable-experimental-web-platform-features flag.
 
 <script>
   const qS = (selector) => {
@@ -138,47 +216,288 @@ The total number of WebNN v1 ops is 60. This table currently lists ops that are 
   const qSA = (selector) => {
     return document.querySelectorAll(selector);
   }
+  
+  const init = () => {
+    let ops = document.querySelector('#ops');
+    fetch("https://webmachinelearning.github.io/assets/json/webnn_status.json")
+      .then(response => response.json())
+      .then(data => {
+        let impl_status = data.impl_status;
+
+        let oplist = '';
+
+        for (let s of impl_status) {
+
+          let spec = `<td class="spec"><a href="https://www.w3.org/TR/webnn/#api-mlgraphbuilder-${s.op_id}">${s.op}</a></td>`
+
+          let wpt = '';
+          if (s.wpt_progress === 4) {
+            wpt = `<td class="wpt_s">
+                      <a href="https://wpt.fyi/results/webnn/${s.wpt}.https.any.html?label=master&amp;label=experimental">📈</a> 
+                      <a href="https://github.com/web-platform-tests/wpt/blob/master/webnn/${s.wpt}.https.any.js">🧪</a></td>`
+          } 
+          if (s.wpt_progress === 3) {
+            wpt = `<td class="wpt_wip">🚀🚀</td>`
+          }
+
+          let xnnpack = '';
+          if (s.xnnpack_op.toString().trim() === "") {
+            xnnpack = `<td></td><td>${s.xnnpack_chromium_version_added}</td>`;
+          } else if (s.xnnpack_progress === 4) {
+            let xnnpack_ops = '';
+            if (s.xnnpack_op.length > 1) {
+              for (let o of s.xnnpack_op) {
+                xnnpack_ops = `✅ ${o} <br/>`;
+                xnnpack += xnnpack_ops;
+              }
+            } else if (s.xnnpack_op.length === 1) {
+              xnnpack = '✅ ' + s.xnnpack_op;
+            } else {
+              xnnpack = ``
+            }
+            xnnpack = `<td class="x_s">${xnnpack}</td><td>${s.xnnpack_chromium_version_added}</td>`;
+          } else if (s.xnnpack_progress === 3) {
+            let xnnpack_ops = '';
+            if (s.xnnpack_op.length > 1) {
+              for (let o of s.xnnpack_op) {
+                xnnpack_ops = `🚀 ${o} <br/>`;
+                xnnpack += xnnpack_ops;
+              }
+            } else if (s.xnnpack_op.length === 1) {
+              xnnpack = '🚀 ' + s.xnnpack_op;
+            } else {
+              xnnpack = ``
+            }
+            xnnpack = `<td class="x_wip">${xnnpack}</td><td>${s.xnnpack_chromium_version_added}</td>`;
+          } else if (s.xnnpack_progress === 2) {
+            let xnnpack_ops = '';
+            if (s.xnnpack_op.length > 1) {
+              for (let o of s.xnnpack_op) {
+                xnnpack_ops = `📅 ${o} <br/>`;
+                xnnpack += xnnpack_ops;
+              }
+            } else if (s.xnnpack_op.length === 1) {
+              xnnpack = '📅 ' + s.xnnpack_op;
+            } else {
+              xnnpack = ``
+            }
+            xnnpack = `<td class="x_plan">${xnnpack}</td><td>${s.xnnpack_chromium_version_added}</td>`;
+          } else {
+            xnnpack = `<td></td><td>${s.xnnpack_chromium_version_added}</td>`;
+          }
+
+          let dml = '';
+          if (s.dml_op.toString().trim() === "") {
+            dml = `<td></td><td>${s.dml_chromium_version_added}</td>`;
+          } else if (s.dml_progress === 4) {
+            let dml_ops = '';
+            if (s.dml_op.length > 1) {
+              for (let o of s.dml_op) {
+                dml_ops = `✅ ${o} <br/>`;
+                dml += dml_ops;
+              }
+            } else if (s.dml_op.length === 1) {
+              dml = '✅ ' + s.dml_op;
+            } else {
+              dml = ``
+            }
+            dml = `<td class="dml_s">${dml}</td><td>${s.dml_chromium_version_added}</td>`;
+          } else if (s.dml_progress === 3) {
+            let dml_ops = '';
+            if (s.dml_op.length > 1) {
+              for (let o of s.dml_op) {
+                dml_ops = `🚀 ${o} <br/>`;
+                dml += dml_ops;
+              }
+            } else if (s.dml_op.length === 1) {
+              dml = '🚀 ' + s.dml_op;
+            } else {
+              dml = ``
+            }
+            dml = `<td class="dml_wip">${dml}</td><td>${s.dml_chromium_version_added}</td>`;
+          } else if (s.dml_progress === 2) {
+            let dml_ops = '';
+            if (s.dml_op.length > 1) {
+              for (let o of s.dml_op) {
+                dml_ops = `📅 ${o} <br/>`;
+                dml += dml_ops;
+              }
+            } else if (s.dml_op.length === 1) {
+              dml = '📅 ' + s.dml_op;
+            } else {
+              dml = ``
+            }
+            dml = `<td class="dml_plan">${dml}</td><td>${s.dml_chromium_version_added}</td>`;
+          } else {
+            dml = `<td></td><td>${s.dml_chromium_version_added}</td>`;
+          }
+
+          let tflite = '';
+          if (s.tflite_op.toString().trim() === "") {
+            tflite = `<td></td><td>${s.tflite_version_added}</td>`;
+          } else if (s.tflite_progress === 4) {
+            let tflite_ops = '';
+            if (s.tflite_op.length > 1) {
+              for (let o of s.tflite_op) {
+                tflite_ops = `✅ ${o} <br/>`;
+                tflite += tflite_ops;
+              }
+            } else if (s.tflite_op.length === 1) {
+              tflite = '✅ ' + s.tflite_op;
+            } else {
+              tflite = ``
+            }
+            tflite = `<td class="ed_s">${tflite}</td><td>${s.tflite_version_added}</td>`;
+          } else if (s.tflite_progress === 3) {
+            let tflite_ops = '';
+            if (s.tflite_op.length > 1) {
+              for (let o of s.tflite_op) {
+                tflite_ops = `🚀 ${o} <br/>`;
+                tflite += tflite_ops;
+              }
+            } else if (s.tflite_op.length === 1) {
+              tflite = '🚀 ' + s.tflite_op;
+            } else {
+              tflite = ``
+            }
+            tflite = `<td class="ed_wip">${tflite}</td><td>${s.tflite_version_added}</td>`;
+          } else if (s.tflite_progress === 2) {
+            let tflite_ops = '';
+            if (s.tflite_op.length > 1) {
+              for (let o of s.tflite_op) {
+                tflite_ops = `📅 ${o} <br/>`;
+                tflite += tflite_ops;
+              }
+            } else if (s.tflite_op.length === 1) {
+              tflite = '📅 ' + s.tflite_op;
+            } else {
+              tflite = ``
+            }
+            tflite = `<td class="ed_plan">${tflite}</td><td>${s.tflite_version_added}</td>`;
+          } else {
+            tflite = `<td></td><td>${s.tflite_version_added}</td>`;
+          }
+
+          let ort = '';
+          if (s.ort_op.toString().trim() === "") {
+            ort = `<td></td><td>${s.ort_version_added}</td>`;
+          } else if (s.ort_progress === 4) {
+            let ort_ops = '';
+            if (s.ort_op.length > 1) {
+              for (let o of s.ort_op) {
+                ort_ops = `✅ ${o} <br/>`;
+                ort += ort_ops;
+              }
+            } else if (s.ort_op.length === 1) {
+              ort = '✅ ' + s.ort_op;
+            } else {
+              ort = ``
+            }
+            ort = `<td class="ep_s">${ort}</td><td>${s.ort_version_added}</td>`;
+          } else if (s.ort_progress === 3) {
+            let ort_ops = '';
+            if (s.ort_op.length > 1) {
+              for (let o of s.ort_op) {
+                ort_ops = `🚀 ${o} <br/>`;
+                ort += ort_ops;
+              }
+            } else if (s.ort_op.length === 1) {
+              ort = '🚀 ' + s.ort_op;
+            } else {
+              ort = ``
+            }
+            ort = `<td class="ep_wip">${ort}</td><td>${s.ort_version_added}</td>`;
+          } else if (s.ort_progress === 2) {
+            let ort_ops = '';
+            if (s.ort_op.length > 1) {
+              for (let o of s.ort_op) {
+                ort_ops = `📅 ${o} <br/>`;
+                ort += ort_ops;
+              }
+            } else if (s.ort_op.length === 1) {
+              ort = '📅 ' + s.ort_op;
+            } else {
+              ort = ``
+            }
+            ort = `<td class="ep_plan">${ort}</td><td>${s.ort_version_added}</td>`;
+          } else {
+            ort = `<td></td><td>${s.ort_version_added}</td>`;
+          }
+
+          oplist += `
+              <tr>
+                ${spec}
+                ${wpt}
+                ${xnnpack}
+                ${dml}
+                ${tflite}
+                ${ort}
+              </tr>
+          `;
+        }
+
+        oplist = oplist + `
+          <tr>
+            <th id="spec_total"></th>
+            <th id="wpt_total"></th>
+            <th id="x_total" colspan="2"></th>
+            <th id="dml_total" colspan="2"></th>
+            <th id="ed_total" colspan="2"></th>
+            <th id="ep_total" colspan="2"></th>
+          </tr>
+        `;
+        ops.innerHTML = oplist;
+        count();
+      })
+      .catch(console.error);
+  }
 
   const count = () => {
     let spec_v1_defined_total = 60; 
 
     let spec_s = qSA('.spec').length;
     let spec_percentage = (spec_s / spec_v1_defined_total * 100).toFixed(1) ;
-    qS('#spec_total').innerHTML = `${spec_percentage}%`;
+    qS('#spec_total').innerHTML = `${spec_s} / ${spec_v1_defined_total}, ${spec_percentage}%`;
   
     let wpt_s = qSA('.wpt_s').length;
     let wpt_percentage = (wpt_s / spec_v1_defined_total * 100).toFixed(1) ;
-    qS('#wpt_total').innerHTML = `${wpt_percentage}%`;
+    qS('#wpt_total').innerHTML = `${wpt_s} / ${spec_v1_defined_total}, ${wpt_percentage}%`;
 
     let x_s = qSA('.x_s').length;
     let x_pi = qSA('.x_pi').length;
     let x_wip = qSA('.x_wip').length;
-    let x_total = x_s + x_pi + x_wip;
     let x_percentage = (x_s / spec_v1_defined_total * 100).toFixed(1) ;
-    qS('#x_total').innerHTML = `${x_percentage}%`;
-    qS('#supported').innerHTML = `${x_s} / ${spec_v1_defined_total}, ${x_percentage}%`;
-    qS('#partlyimplemented').innerHTML = x_pi;
-    qS('#workinprogress').innerHTML = x_wip;
+    qS('#x_total').innerHTML = `${x_s} / ${spec_v1_defined_total}, ${x_percentage}%`;
+    qS('#x_supported').innerHTML = x_s;
+    qS('#x_partlyimplemented').innerHTML = x_pi;
+    qS('#x_workinprogress').innerHTML = x_wip;
+        
+    let dml_s = qSA('.dml_s').length;
+    let dml_pi = qSA('.dml_pi').length;
+    let dml_wip = qSA('.dml_wip').length;
+    let dml_percentage = (dml_s / spec_v1_defined_total * 100).toFixed(1) ;
+    qS('#dml_total').innerHTML = `${dml_s} / ${spec_v1_defined_total}, ${dml_percentage}%`;
+    qS('#dml_supported').innerHTML = dml_s;
+    qS('#dml_partlyimplemented').innerHTML = dml_pi;
+    qS('#dml_workinprogress').innerHTML = dml_wip;
  
     let ed_s = qSA('.ed_s').length;
     let ed_pi = qSA('.ed_pi').length;
     let ed_wip = qSA('.ed_wip').length;
-    let ed_total = ed_s + ed_pi + ed_wip;
     let ed_percentage = (ed_s / spec_v1_defined_total * 100).toFixed(1) ;
-    qS('#ed_total').innerHTML = `${ed_percentage}%`;
-    qS('#ed_supported').innerHTML = `${ed_s} / ${spec_v1_defined_total}, ${ed_percentage}%`;
+    qS('#ed_total').innerHTML = `${ed_s} / ${spec_v1_defined_total}, ${ed_percentage}%`;
+    qS('#ed_supported').innerHTML = ed_s;
     qS('#ed_partlyimplemented').innerHTML = ed_pi;
     qS('#ed_workinprogress').innerHTML = ed_wip;
 
     let ep_s = qSA('.ep_s').length;
     let ep_pi = qSA('.ep_pi').length;
     let ep_wip = qSA('.ep_wip').length;
-    let ep_total = ep_s + ep_pi + ep_wip;
     let ep_percentage = (ep_s / spec_v1_defined_total * 100).toFixed(1) ;
-    qS('#ep_total').innerHTML = `${ep_percentage}%`;
-    qS('#ep_supported').innerHTML = `${ep_s} / ${spec_v1_defined_total}, ${ep_percentage}%`;
+    qS('#ep_total').innerHTML = `${ep_s} / ${spec_v1_defined_total}, ${ep_percentage}%`;
+    qS('#ep_supported').innerHTML = ep_s;
     qS('#ep_partlyimplemented').innerHTML = ep_pi;
     qS('#ep_workinprogress').innerHTML = ep_wip;
   }
- document.addEventListener('DOMContentLoaded', count, false);
+ document.addEventListener('DOMContentLoaded', init, false);
 </script>


### PR DESCRIPTION
Fix https://github.com/webmachinelearning/webmachinelearning.github.io/issues/51 

Based on the feedback from @anssiko and Chai, extending the implementation status for all 60 v1 ops.

1. Replaced markdown with HTML table to use colspan and rowspan freely, more code lines
2. List implementation status for all 60 v1 ops
3. Clearer distinction of browser implementation and framework
4. "Version Added" column which will be used for MDN [Browser Compat Data](https://github.com/mdn/browser-compat-data/)
5. Add DML backend but list most of them with "WIP" emoji since these efforts are in forked branch, will be submitted into upstream Chromium
6. Map mutiple implementations for 1 op into 1 cell

@Honry @anssiko PTAL

