### PR TITLE
Update implementation status for WebNN DirectML backend

### DIFF
--- a/assets/json/webnn_status.json
+++ b/assets/json/webnn_status.json
@@ -42,8 +42,8 @@
       "dml_op": [
         "ELEMENT_WISE_CLIP"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "ReluN1To1"
       ],
@@ -101,8 +101,8 @@
       "dml_op": [
         "CONVOLUTION"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Conv2d",
         "DepthwiseConv2d"
@@ -159,8 +159,8 @@
       "dml_op": [
         "ELEMENT_WISE_ADD"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Add"
       ],
@@ -187,8 +187,8 @@
       "dml_op": [
         "ELEMENT_WISE_SUBTRACT"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Sub"
       ],
@@ -215,8 +215,8 @@
       "dml_op": [
         "ELEMENT_WISE_MULTIPLY"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Mul"
       ],
@@ -243,8 +243,8 @@
       "dml_op": [
         "ELEMENT_WISE_DIVIDE"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Div"
       ],
@@ -271,8 +271,8 @@
       "dml_op": [
         "ELEMENT_WISE_MAX"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Maximum"
       ],
@@ -299,8 +299,8 @@
       "dml_op": [
         "ELEMENT_WISE_MIN"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Minimum"
       ],
@@ -328,8 +328,8 @@
       "dml_op": [
         "ELEMENT_WISE_POW"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Sqrt",
         "Square"
@@ -637,8 +637,8 @@
       "dml_op": [
         "GEMM"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "FullyConnected"
       ],
@@ -974,8 +974,8 @@
       "dml_op": [
         "AVERAGE_POOLING"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "AveragePool2d",
         "Mean"
@@ -1033,8 +1033,8 @@
       "dml_op": [
         "MAX_POOLING2"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "MaxPool2d"
       ],
@@ -1371,8 +1371,8 @@
       "dml_op": [
         "ACTIVATION_RELU"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Relu"
       ],
@@ -1427,8 +1427,8 @@
       "dml_op": [
         "Supported by tensor strides"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Reshape"
       ],
@@ -1512,8 +1512,8 @@
       "dml_op": [
         "ACTIVATION_SOFTMAX"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "Chromium fork",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M119",
       "tflite_op": [
         "Softmax"
       ],

--- a/webnn-status.md
+++ b/webnn-status.md
@@ -154,7 +154,7 @@ sup {
       <th>
         <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-dev/chrome-dev_128x128.png" />
         <img
-          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>5</sup>
+          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>6</sup>
       </th>
       <th>Operations
       </th>
@@ -200,13 +200,16 @@ sup {
     </div>
 </div> 
 
-The total number of WebNN ops is 60. This table currently lists ops that are implemented or WIP by multiple backends.
+The total number of WebNN ops is 60. This table currently lists ops that are implemented or WIP by multiple backends
 
 <sup>[1]</sup> XNNPack node definition in [`xnn_define_*`](https://github.com/google/XNNPACK/blob/master/include/xnnpack.h)<br/>
 <sup>[2]</sup> [DirectML](https://learn.microsoft.com/en-us/windows/win32/api/_directml/) API<br/>
 <sup>[3]</sup> TensorFlow Lite built-in operators [`kTfLiteBuiltin*`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc)<br/>
 <sup>[4]</sup> ONNX [`Operator Schemas`](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [`WebNN EP Helper`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/webnn/builders/helper.h)<br/>
-<sup>[5]</sup> Currently enabled in [Google Chrome Dev](https://www.google.com/chrome/dev/) and [Microsoft Edge Canary](https://www.microsoftedgeinsider.com/en-us/download/canary) channels with #enable-experimental-web-platform-features flag.
+<sup>[5]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/dev/) and [Microsoft Edge](https://www.microsoftedgeinsider.com/en-us/download/canary) with `#enable-experimental-web-platform-features` flag<br/>
+<sup>[6]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/dev/) and [Microsoft Edge](https://www.microsoftedgeinsider.com/en-us/download/canary) in command line with flags on Windows 11 21H2 or higher: 
+`"%LOCALAPPDATA%\Google\Chrome SxS\Application\chrome.exe" --enable-features=MachineLearningNeuralNetworkService --enable-experimental-web-platform-features`
+
 
 <script>
   const qS = (selector) => {


### PR DESCRIPTION
We've landed the required operators to support MobileNet v2 for WebNN DirectML backend.

@anssiko PTAL, thanks!