### PR TITLE
Update WebNN ops impl status and add ChromeOS platform

### DIFF
--- a/assets/json/webnn_status.json
+++ b/assets/json/webnn_status.json
@@ -16,6 +16,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -44,6 +49,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -72,14 +82,18 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "BatchNormalization",
-        "meanVarianceNormalization"
+        "BatchNormalization"
       ],
       "ort_progress": 4,
       "ort_version_added": "main",
@@ -90,7 +104,7 @@
       "op_id": "cast",
       "version": "",
       "wpt": "cast",
-      "wpt_progress": 3,
+      "wpt_progress": 4,
       "xnnpack_op": [
         ""
       ],
@@ -101,6 +115,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -129,6 +148,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "ReluN1To1"
       ],
@@ -159,6 +183,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M120",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Concatenation"
       ],
@@ -189,6 +218,11 @@
       ],
       "dml_progress": 3,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -197,7 +231,7 @@
       "ort_op": [
         "Range"
       ],
-      "ort_progress": 3,
+      "ort_progress": 4,
       "ort_version_added": "main",
       "notes": ""
     },
@@ -218,6 +252,12 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "CONV_2D",
+        "DEPTHWISE_CONV_2D"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Conv2d",
         "DepthwiseConv2d"
@@ -247,6 +287,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "TransposeConv",
         "Convolution2DTransposeBias"
@@ -276,6 +321,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "ADD"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Add"
       ],
@@ -304,6 +354,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "DIV"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Div"
       ],
@@ -332,6 +387,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "MAXIMUM"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Maximum"
       ],
@@ -360,6 +420,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "MINIMUM"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Minimum"
       ],
@@ -388,6 +453,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "MUL"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Mul"
       ],
@@ -417,6 +487,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "POW"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Sqrt",
         "Square"
@@ -426,8 +501,8 @@
       "ort_op": [
         "Pow"
       ],
-      "ort_progress": 1,
-      "ort_version_added": "",
+      "ort_progress": 4,
+      "ort_version_added": "main",
       "notes": "XNNPACK: Pow will be replaced by Sqrt. square/square_root"
     },
     {
@@ -446,6 +521,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "SUB"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Sub"
       ],
@@ -474,6 +554,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -502,6 +587,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -530,6 +620,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -558,6 +653,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -586,6 +686,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -614,6 +719,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -642,6 +752,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Abs"
       ],
@@ -670,6 +785,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Ceil"
       ],
@@ -683,7 +803,7 @@
       "notes": ""
     },
     {
-      "op": "element-wise unary / copy",
+      "op": "element-wise unary / identity",
       "op_id": "unary",
       "version": "",
       "wpt": "elementwise_unary",
@@ -698,6 +818,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -726,6 +851,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -754,6 +884,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -782,6 +917,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -810,6 +950,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Floor"
       ],
@@ -838,6 +983,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -866,6 +1016,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Neg"
       ],
@@ -894,6 +1049,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -922,6 +1082,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -944,13 +1109,18 @@
         "square",
         "square_root"
       ],
-      "xnnpack_progress": 2,
-      "xnnpack_chromium_version_added": "",
+      "xnnpack_progress": 4,
+      "xnnpack_chromium_version_added": "M122",
       "dml_op": [
         "ELEMENT_WISE_SQRT"
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -979,6 +1149,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1007,6 +1182,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Elu"
       ],
@@ -1035,6 +1215,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1052,7 +1237,7 @@
       "op_id": "gather",
       "version": "",
       "wpt": "gather",
-      "wpt_progress": 3,
+      "wpt_progress": 4,
       "xnnpack_op": [
         ""
       ],
@@ -1063,6 +1248,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1091,6 +1281,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "FullyConnected"
       ],
@@ -1119,13 +1314,18 @@
       ],
       "dml_progress": 2,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "GRU"
+        "Gru"
       ],
       "ort_progress": 3,
       "ort_version_added": "",
@@ -1147,13 +1347,18 @@
       ],
       "dml_progress": 2,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "GRU"
+        "GruCell"
       ],
       "ort_progress": 3,
       "ort_version_added": "",
@@ -1173,8 +1378,13 @@
       "dml_op": [
         "ACTIVATION_HARD_SIGMOID"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M123",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1203,6 +1413,11 @@
       ],
       "dml_progress": 2,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "HardSwish"
       ],
@@ -1220,7 +1435,7 @@
       "op_id": "instancenorm",
       "version": "",
       "wpt": "instance_normalization",
-      "wpt_progress": 3,
+      "wpt_progress": 4,
       "xnnpack_op": [
         ""
       ],
@@ -1231,14 +1446,18 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "InstanceNormalization",
-        "meanVarianceNormalization"
+        "InstanceNormalization"
       ],
       "ort_progress": 4,
       "ort_version_added": "main",
@@ -1260,14 +1479,18 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "LayerNormalization",
-        "meanVarianceNormalization"
+        "LayerNormalization"
       ],
       "ort_progress": 4,
       "ort_version_added": "main",
@@ -1289,6 +1512,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "LeakyRelu"
       ],
@@ -1315,18 +1543,23 @@
       "dml_op": [
         "ACTIVATION_LINEAR"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        ""
+        "N/A"
       ],
-      "ort_progress": 2,
-      "ort_version_added": "",
+      "ort_progress": 4,
+      "ort_version_added": "main",
       "notes": ""
     },
     {
@@ -1345,6 +1578,11 @@
       ],
       "dml_progress": 2,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1373,13 +1611,18 @@
       ],
       "dml_progress": 2,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "LSTM"
+        "LSTMCell"
       ],
       "ort_progress": 3,
       "ort_version_added": "",
@@ -1401,6 +1644,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1429,6 +1677,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M120",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Pad"
       ],
@@ -1458,6 +1711,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "AVERAGE_POOL_2D"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "AveragePool2d",
         "Mean"
@@ -1488,6 +1746,11 @@
       ],
       "dml_progress": 3,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1517,6 +1780,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "MAX_POOL_2D"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "MaxPool2d"
       ],
@@ -1546,6 +1814,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M120",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Prelu"
       ],
@@ -1574,6 +1847,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1602,6 +1880,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1630,6 +1913,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1658,6 +1946,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1686,6 +1979,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1714,6 +2012,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1742,6 +2045,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1770,6 +2078,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1799,6 +2112,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1827,6 +2145,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -1855,6 +2178,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "RELU"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Relu"
       ],
@@ -1883,6 +2211,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "ResizeBilinear"
       ],
@@ -1911,13 +2244,21 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "RESHAPE"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Reshape"
       ],
       "tflite_progress": 3,
       "tflite_version_added": "Fork",
       "ort_op": [
-        "Reshape"
+        "Unsqueeze",
+        "Squeeze",
+        "Reshape",
+        "Flatten"
       ],
       "ort_progress": 4,
       "ort_version_added": "main",
@@ -1939,6 +2280,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Logistic"
       ],
@@ -1967,6 +2313,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M120",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Slice",
         "StridedSlice"
@@ -1974,7 +2325,8 @@
       "tflite_progress": 3,
       "tflite_version_added": "Fork",
       "ort_op": [
-        "Slice"
+        "Slice",
+        "Shape"
       ],
       "ort_progress": 4,
       "ort_version_added": "main",
@@ -1996,6 +2348,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M119",
+      "mlservice_op": [
+        "SOFTMAX"
+      ],
+      "mlservice_progress": 4,
+      "mlservice_chromium_version_added": "M122",
       "tflite_op": [
         "Softmax"
       ],
@@ -2022,8 +2379,13 @@
       "dml_op": [
         "ACTIVATION_SOFTPLUS"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -2050,8 +2412,13 @@
       "dml_op": [
         "ACTIVATION_SOFTSIGN"
       ],
-      "dml_progress": 3,
-      "dml_chromium_version_added": "",
+      "dml_progress": 4,
+      "dml_chromium_version_added": "M123",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -2083,6 +2450,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M120",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Split"
       ],
@@ -2111,6 +2483,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M121",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -2139,6 +2516,11 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M120",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         "Transpose"
       ],
@@ -2167,6 +2549,11 @@
       ],
       "dml_progress": 3,
       "dml_chromium_version_added": "",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
@@ -2195,14 +2582,18 @@
       ],
       "dml_progress": 4,
       "dml_chromium_version_added": "M122",
+      "mlservice_op": [
+        ""
+      ],
+      "mlservice_progress": 2,
+      "mlservice_chromium_version_added": "",
       "tflite_op": [
         ""
       ],
       "tflite_progress": 2,
       "tflite_version_added": "",
       "ort_op": [
-        "Where",
-        "elementwiseIf"
+        "Where"
       ],
       "ort_progress": 4,
       "ort_version_added": "main",

--- a/webnn-status.md
+++ b/webnn-status.md
@@ -38,6 +38,16 @@ permalink: /webnn-status/
   text-align: center;
 }
 
+.post table.framework tr td:nth-child(2), 
+.post table.framework tr td:nth-child(4) {
+  text-align: left;
+}
+
+.post table.framework tr td:nth-child(3), 
+.post table.framework tr td:nth-child(5) {
+  text-align: center;
+}
+
 .post table td {
   padding: 4px 4px;
   vertical-align: middle;
@@ -50,7 +60,17 @@ permalink: /webnn-status/
 .impl_status {
    text-align: center;
    display: grid; 
-   grid-template-columns: 1fr 1fr 1fr 1fr;
+   grid-template-columns: 1fr 1fr 1fr;
+   gap: 0px;
+   border: 1px solid #dfe2e5;
+   padding: 12px;
+   font-size: 0.9em;
+}
+
+.impl_status_framework {
+   text-align: center;
+   display: grid; 
+   grid-template-columns: 1fr 1fr;
    gap: 0px;
    border: 1px solid #dfe2e5;
    padding: 12px;
@@ -83,6 +103,18 @@ sup {
 
 .impl_status div {
   margin: 0 12px;
+}
+
+#cros {
+  width: 6.4rem;
+  height: 3.2rem;
+  margin-left: 2px;
+  margin-bottom: -3px;
+  transform: rotateY(0deg) rotate(0deg);
+}
+
+.mt-2 {
+  margin-top: 20px;
 }
 </style>
 
@@ -122,47 +154,191 @@ sup {
         </a>
       </th>
       <th rowspan="3">Web Platform<br />Tests</th>
-      <th colspan="4">
+      <th colspan="6">
         Chromium Implementation
       </th>
-      <th colspan="4">JavaScript ML Frameworks Integration</th>
     </tr>
     <tr class="title">
       <th colspan="2"><img src="https://wpt.fyi/static/win.svg"> <img
-          src="https://wpt.fyi/static/linux.svg"><br />XNNPack/CPU
+          src="https://wpt.fyi/static/linux.svg"><br />XNNPack · CPU
         backend
         <sup>1</sup>
       </th>
-      <th colspan="2"><img src="https://wpt.fyi/static/win.svg"><br />DirectML/GPU backend <sup>2</sup>
+      <th colspan="2"><img src="https://wpt.fyi/static/win.svg"><br />DirectML · GPU backend <sup>2</sup>
       </th>
-      <th colspan="2"><img
-          src="https://www.gstatic.com/devrel-devsite/prod/v8ec4d0a037302c47ae529ad4e3f06c9e782b3a31a381294b5a70403547dc6b12/tensorflow/images/lockup.svg">
-        Lite for TF.js<br />External Delegate <sup>3</sup></th>
-      <th colspan="2"><img src="https://onnxruntime.ai/images/svg/ONNX-Runtime-logo.svg" /><br />Execution Provider
-        <sup>4</sup>
+         <th colspan="2">
+          <svg id="cros"
+            width="67.775795mm"
+            height="14.390643mm"
+            viewBox="0 0 67.775795 14.390643"
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:svg="http://www.w3.org/2000/svg">
+            <sodipodi:namedview
+              id="namedview1"
+              pagecolor="#ffffff"
+              bordercolor="#000000"
+              borderopacity="0.25"
+              inkscape:showpageshadow="2"
+              inkscape:pageopacity="0.0"
+              inkscape:pagecheckerboard="0"
+              inkscape:deskcolor="#d1d1d1"
+              inkscape:document-units="mm" />
+            <defs
+              id="defs1">
+              <linearGradient
+                id="a"
+                x1="3.2172999"
+                y1="15"
+                x2="44.7812"
+                y2="15"
+                gradientUnits="userSpaceOnUse">
+                <stop
+                  offset="0"
+                  stop-color="#d93025"
+                  id="stop1" />
+                <stop
+                  offset="1"
+                  stop-color="#ea4335"
+                  id="stop2" />
+              </linearGradient>
+              <linearGradient
+                id="b"
+                x1="20.721901"
+                y1="47.6791"
+                x2="41.503899"
+                y2="11.6837"
+                gradientUnits="userSpaceOnUse">
+                <stop
+                  offset="0"
+                  stop-color="#fcc934"
+                  id="stop3" />
+                <stop
+                  offset="1"
+                  stop-color="#fbbc04"
+                  id="stop4" />
+              </linearGradient>
+              <linearGradient
+                id="c"
+                x1="26.598101"
+                y1="46.501499"
+                x2="5.8161001"
+                y2="10.506"
+                gradientUnits="userSpaceOnUse">
+                <stop
+                  offset="0"
+                  stop-color="#1e8e3e"
+                  id="stop5" />
+                <stop
+                  offset="1"
+                  stop-color="#34a853"
+                  id="stop6" />
+              </linearGradient>
+            </defs>
+            <g
+              inkscape:label="Livello 1"
+              inkscape:groupmode="layer"
+              id="layer1"
+              transform="translate(-127.52917,-127.79374)">
+              <path
+                fill="#5f6368"
+                d="m 189.71962,134.80547 a 4.0613541,4.0613541 0 0 1 -4.06136,4.06135 4.0613541,4.0613541 0 0 1 -4.06135,-4.06135 4.0613541,4.0613541 0 0 1 4.06135,-4.06136 4.0613541,4.0613541 0 0 1 4.06136,4.06136 z m -4.03408,3.12459 a 3.127375,3.0241875 89.5 0 0 2.99681,-3.15362 3.127375,3.0241875 89.5 0 0 -3.05136,-3.10086 3.127375,3.0241875 89.5 0 0 -2.99681,3.15362 3.127375,3.0241875 89.5 0 0 3.05136,3.10086 z"
+                id="path9"
+                inkscape:export-filename="path9.svg"
+                inkscape:export-xdpi="96"
+                inkscape:export-ydpi="96"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 195.30497,136.34005 v 0.61648 q -0.82814,2.46062 -3.50573,1.76212 -1.30439,-0.34131 -1.86531,-1.88648 a 0.07408333,0.07408333 0 0 1 0.0423,-0.0952 l 0.7673,-0.30427 q 0.0714,-0.0291 0.10054,0.0423 0.66939,1.64041 2.22514,1.39964 c 0.85196,-0.12964 1.44727,-0.92339 1.07421,-1.75948 -0.39423,-0.88635 -1.93939,-1.12448 -2.74637,-1.52664 -1.77007,-0.88636 -1.4949,-3.11944 0.28046,-3.67771 q 2.16429,-0.67998 3.34168,1.29117 a 0.08995833,0.09260417 62.5 0 1 -0.0423,0.12964 l -0.73819,0.33073 a 0.08202083,0.08466667 63.5 0 1 -0.10848,-0.0344 q -0.72231,-1.24618 -2.05581,-0.84402 c -0.75671,0.23019 -1.20121,1.1483 -0.50535,1.72244 0.62177,0.51329 1.49489,0.64029 2.29129,1.00013 q 1.2065,0.54768 1.44462,1.83356 z"
+                id="path10"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 152.04031,133.97732 q 1.1721,-1.21708 2.61408,-0.53975 0.98425,0.45773 1.016,1.7489 0.037,1.53458 0.008,3.43958 -0.003,0.0741 -0.0741,0.0741 l -0.83079,-0.003 q -0.0661,0 -0.0688,-0.0661 -0.045,-1.39965 0.005,-2.68287 c 0.0423,-1.06098 -0.2831,-2.032 -1.59014,-1.80975 -0.80434,0.13493 -1.16946,0.94456 -1.16417,1.70127 q 0.005,1.41287 0.005,2.74637 0,0.10848 -0.11112,0.11113 l -0.7329,0.005 q -0.14023,0 -0.14023,-0.14023 v -7.52475 q 0,-0.13229 0.12965,-0.12965 l 0.75671,0.0185 q 0.11112,0.003 0.11112,0.11377 l -0.0476,2.8919 q -0.003,0.16404 0.11377,0.045 z"
+                id="path11"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 147.54768,137.94342 q 1.06627,0.0503 1.56898,-0.84931 0.0741,-0.13229 0.21167,-0.0714 l 0.60854,0.26723 q 0.14023,0.0609 0.0661,0.19315 -0.85989,1.55839 -2.7305,1.34144 c -1.90764,-0.21961 -2.82575,-2.28071 -2.12725,-3.9423 0.87313,-2.07697 3.73063,-2.31775 4.84188,-0.27516 q 0.0608,0.11112 -0.0556,0.15875 l -0.67204,0.29104 a 0.15875,0.15875 0 0 1 -0.20373,-0.0741 q -0.4154,-0.8308 -1.31763,-0.87313 c -2.29394,-0.11112 -2.43946,3.72533 -0.1905,3.83381 z"
+                id="path15"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 162.97363,138.88254 a 2.8495625,2.7807708 89.4 0 1 -2.81046,-2.82028 2.8495625,2.7807708 89.4 0 1 2.75077,-2.87853 2.8495625,2.7807708 89.4 0 1 2.81046,2.82027 2.8495625,2.7807708 89.4 0 1 -2.75077,2.87854 z m -0.0238,-0.9206 a 1.9314583,1.7727083 89.9 0 0 1.76935,-1.93455 1.9314583,1.7727083 89.9 0 0 -1.77607,-1.92836 1.9314583,1.7727083 89.9 0 0 -1.76935,1.93455 1.9314583,1.7727083 89.9 0 0 1.77607,1.92836 z"
+                id="path16"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 167.68512,133.97997 c 0.33867,-0.28575 0.64558,-0.57415 1.09008,-0.68792 q 1.17211,-0.29633 1.92881,0.48419 a 0.69585416,0.68262499 13.8 0 1 0.15875,0.25664 q 0.0159,0.0503 0.0609,0.0847 0.10054,0.0767 0.17198,-0.0265 0.57944,-0.82021 1.54252,-0.87048 1.93939,-0.0952 2.12989,1.87061 0.082,0.83608 0.0238,3.4925 -0.003,0.11641 -0.12171,0.11641 h -0.80433 q -0.11907,0 -0.11642,-0.11906 0.0106,-1.50813 -0.005,-3.19352 c -0.0159,-1.99496 -2.45004,-1.47902 -2.49238,0.12171 q -0.0503,1.87854 -0.0238,3.05329 0.003,0.13758 -0.13494,0.13758 l -0.78316,-0.003 q -0.1323,0 -0.12965,-0.1323 0.0265,-1.4896 -0.005,-3.15647 c -0.0397,-2.02142 -2.42623,-1.49755 -2.48709,0.0661 q -0.0688,1.67746 -0.0265,3.09298 0.003,0.13494 -0.12965,0.13229 h -0.80169 a 0.1031875,0.10054167 0 0 1 -0.10318,-0.10054 l -0.003,-5.06942 q 0,-0.17991 0.17992,-0.17991 l 0.64293,0.003 q 0.17198,0.003 0.15346,0.17463 l -0.037,0.38629 q -0.0212,0.18521 0.12171,0.0662 z"
+                id="path17"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 176.65714,136.39297 q 0.16669,0.96572 0.84931,1.31762 1.40494,0.72231 2.35744,-0.59531 0.0397,-0.0529 0.0979,-0.0291 l 0.70643,0.30427 q 0.0662,0.0291 0.0344,0.0952 c -0.49742,1.00013 -1.47638,1.4605 -2.59027,1.35203 -2.70669,-0.26194 -3.39196,-4.0349 -1.05304,-5.32871 0.98689,-0.54504 2.44475,-0.35984 3.19352,0.54239 q 0.71437,0.86254 0.63235,2.02142 -0.0106,0.16933 -0.18256,0.16933 l -3.91319,-0.008 q -0.15875,0 -0.13229,0.15875 z m 0.16404,-0.99748 2.96863,-0.0106 a 0.03439583,0.03439583 0 0 0 0.0344,-0.0344 v -0.0238 a 1.2012083,1.4896041 89.8 0 0 -1.49489,-1.19591 h -0.0582 a 1.2012083,1.4896041 89.8 0 0 -1.48431,1.2065 v 0.0238 a 0.03439583,0.03439583 0 0 0 0.0344,0.0344 z"
+                id="path18"
+                style="stroke-width:0.264583" />
+              <path
+                fill="#5f6368"
+                d="m 158.0146,134.08051 q 0.66146,-1.06892 2.10344,-0.73554 a 0.079375,0.079375 0 0 1 0.0556,0.10847 l -0.29634,0.74348 a 0.1349375,0.1349375 0 0 1 -0.15345,0.082 c -1.15888,-0.254 -1.85473,0.57415 -1.81769,1.68805 q 0.0476,1.44462 0.003,2.63525 -0.005,0.10054 -0.10583,0.10054 l -0.79639,-0.005 a 0.1349375,0.13229166 0 0 1 -0.13494,-0.1323 v -5.08793 q 0,-0.127 0.12964,-0.127 l 0.73555,0.003 a 0.14022916,0.13758333 4.3 0 1 0.13758,0.15611 q -0.037,0.2831 0.0106,0.54768 0.0344,0.17728 0.12965,0.0238 z"
+                id="path19"
+                style="stroke-width:0.264583" />
+              <g
+                id="g19"
+                transform="matrix(0.30224767,0,0,0.29980472,127.52917,127.79376)"
+                style="display:inline">
+                <circle
+                  cx="24"
+                  cy="23.994699"
+                  r="12"
+                  style="fill:#ffffff"
+                  id="circle6" />
+                <path
+                  d="M 3.2154,36 A 24,24 0 1 0 12,3.2154 24,24 0 0 0 3.2154,36 Z M 34.3923,18 A 12,12 0 1 1 18,13.6077 12,12 0 0 1 34.3923,18 Z"
+                  style="fill:none"
+                  id="path6-1" />
+                <path
+                  d="M 24,12 H 44.7812 A 23.9939,23.9939 0 0 0 3.2173,12.0029 L 13.6079,30 13.6172,29.9976 A 11.9852,11.9852 0 0 1 24,12 Z"
+                  style="fill:url(#a)"
+                  id="path7-2" />
+                <circle
+                  cx="24"
+                  cy="24"
+                  r="9.5"
+                  style="fill:#1a73e8"
+                  id="circle7" />
+                <path
+                  d="M 34.3913,30.0029 24.0007,48 A 23.994,23.994 0 0 0 44.78,12.0031 H 23.9989 l -0.0025,0.0093 a 11.985,11.985 0 0 1 10.3949,17.9905 z"
+                  style="fill:url(#b)"
+                  id="path8-0" />
+                <path
+                  d="M 13.6086,30.0031 3.218,12.006 A 23.994,23.994 0 0 0 24.0025,48 L 34.3931,30.0029 34.3864,29.9961 a 11.9852,11.9852 0 0 1 -20.7778,0.007 z"
+                  style="fill:url(#c)"
+                  id="path9-4" />
+              </g>
+            </g>
+          </svg>
+
+         <br />MLService · CPU backend <sup>3</sup>
       </th>
     </tr>
     <tr class="title">
       <th>Operations
       </th>
       <th>
-        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-dev/chrome-dev_128x128.png" />
+        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-canary/chrome-canary_128x128.png" />
         <img
-          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>5</sup>
+          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>4</sup>
       </th>
       <th>Operations</th>
       <th>
-        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-dev/chrome-dev_128x128.png" />
+        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-canary/chrome-canary_128x128.png" />
         <img
-          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>6</sup>
+          src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge-canary/edge-canary_128x128.png" /> <sup>5</sup>
       </th>
-      <th>Operations
-      </th>
-      <th>Delegate Version
-      </th>
-      <th>Operations
-      </th>
-      <th>EP Version
+       <th>Operations</th>
+      <th>
+        <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome-canary/chrome-canary_128x128.png" /> <sup>6</sup>
       </th>
     </tr>
   </thead>
@@ -172,8 +348,7 @@ sup {
 <div class="impl_status">
     <div class="title">XNNPack/CPU backend</div>
     <div class="title">DirectML/GPU backend</div>
-    <div class="title">TensorFlow.js/TFLite<br/>External Delegate</div>
-    <div class="title">ONNX Runtime Web<br/>Execution Provider</div>
+    <div class="title">MLServie/CPU backend</div>
     <div>
         <div>✅ Supported (<span id="x_supported"></span>)</div>
         <div>⏳ Partly Implemented (<span id="x_partlyimplemented"></span>)</div>
@@ -186,6 +361,78 @@ sup {
         <div>🚀 Work in Progress (<span id="dml_workinprogress"></span>)</div>
         <div>❌ Not Supported</div>
     </div>
+        <div>
+        <div>✅ Supported (<span id="mlservice_supported"></span>)</div>
+        <div>⏳ Partly Implemented (<span id="mlservice_partlyimplemented"></span>)</div>
+        <div>🚀 Work in Progress (<span id="mlservice_workinprogress"></span>)</div>
+        <div>❌ Not Supported</div>
+    </div>
+</div> 
+
+<h1 class="post-title mt-2">JavaScript ML Frameworks Integration Status</h1>
+
+<table class="framework">
+  <thead>
+    <tr class="title">
+      <th rowspan="3">
+        <a href="https://www.w3.org/TR/webnn/">
+          <svg id="w3" x="0px" y="0px" viewBox="0 0 357.5 287" style="enable-background:new 0 0 357.5 287;">
+            <style type="text/css">
+              .st0 {
+                fill: #005A9C;
+              }
+
+              .st1 {
+                fill: #221B0A;
+              }
+            </style>
+            <g>
+              <path class="st0" d="M118.4,76.6l24.2,82.4l24.2-82.4h17.5l-40.1,135.3h-1.7l-25.1-83.8l-25.1,83.8h-1.7L50.8,76.6h17.5L92.5,159
+                    l16.4-55.5l-8-26.9L118.4,76.6L118.4,76.6z" />
+              <path class="st0" d="M234.2,168.5c0,12.3-3.3,22.6-9.8,30.9c-6.5,8.3-15,12.5-25.3,12.5c-7.8,0-14.6-2.5-20.4-7.4
+                    c-5.8-5-10.1-11.7-12.9-20.1l13.7-5.7c2,5.1,4.7,9.2,7.9,12.1c3.3,2.9,7.1,4.4,11.6,4.4c4.7,0,8.6-2.6,11.9-7.9
+                    c3.2-5.2,4.8-11.5,4.8-18.9c0-8.1-1.7-14.4-5.2-18.9c-4-5.2-10.3-7.9-18.9-7.9h-6.7v-8l23.4-40.4h-28.2l-7.9,13.4h-5V76.6h65.1v8.2
+                    l-24.7,42.6c8.7,2.8,15.3,7.9,19.7,15.2C232,149.9,234.2,158.6,234.2,168.5L234.2,168.5z" />
+              <path class="st1"
+                d="M302.2,75.9l2.8,17.3l-10.1,19.2c0,0-3.9-8.2-10.3-12.7c-5.4-3.8-8.9-4.6-14.4-3.5
+                    c-7.1,1.5-15.1,9.9-18.6,20.3c-4.2,12.5-4.2,18.5-4.4,24c-0.2,8.9,1.2,14.1,1.2,14.1s-6.1-11.3-6-27.8c0-11.8,1.9-22.5,7.4-33.1
+                    c4.8-9.3,11.9-14.9,18.3-15.5c6.6-0.7,11.7,2.5,15.7,5.9c4.2,3.6,8.5,11.4,8.5,11.4L302.2,75.9L302.2,75.9z" />
+              <path class="st1" d="M303.4,173.6c0,0-4.4,7.9-7.2,11c-2.8,3.1-7.7,8.5-13.8,11.2c-6.1,2.7-9.3,3.2-15.4,2.6
+                    c-6-0.6-11.7-4.1-13.6-5.5c-2-1.4-7-5.8-9.8-9.7c-2.9-4-7.3-12-7.3-12s2.5,8,4,11.4c0.9,2,3.6,8,7.5,13.2
+                    c3.6,4.9,10.7,13.3,21.4,15.1c10.7,1.9,18.1-2.9,19.9-4.1c1.8-1.2,5.7-4.4,8.1-7c2.5-2.7,4.9-6.2,6.3-8.2c1-1.5,2.6-4.6,2.6-4.6
+                    L303.4,173.6L303.4,173.6z" />
+            </g>
+          </svg>
+          <br />WebNN Spec
+        </a>
+      </th>
+      <th colspan="4">JavaScript ML Frameworks Integration</th>
+    </tr>
+    <tr class="title">
+      <th colspan="2"><img
+          src="https://www.gstatic.com/devrel-devsite/prod/v8ec4d0a037302c47ae529ad4e3f06c9e782b3a31a381294b5a70403547dc6b12/tensorflow/images/lockup.svg">
+        Lite for TF.js<br />External Delegate <sup>7</sup></th>
+      <th colspan="2"><img src="https://onnxruntime.ai/images/svg/ONNX-Runtime-logo.svg" /><br />Execution Provider
+        <sup>8</sup>
+      </th>
+    </tr>
+    <tr class="title">
+      <th>Operations
+      </th>
+      <th>Delegate Version
+      </th>
+      <th>Operations
+      </th>
+      <th>EP Version
+      </th>
+    </tr>
+  </thead>
+  <tbody id="ops_framework"></tbody>
+</table>
+
+<div class="impl_status_framework">
+    <div class="title">TensorFlow.js/TFLite<br/>External Delegate</div>
+    <div class="title">ONNX Runtime Web<br/>Execution Provider</div>
     <div>
         <div>✅ Supported (<span id="ed_supported"></span>)</div>
         <div>⏳ Partly Implemented (<span id="ed_partlyimplemented"></span>)</div>
@@ -200,15 +447,19 @@ sup {
     </div>
 </div> 
 
-The total number of WebNN ops is 78. This table currently lists ops that are implemented or WIP by multiple backends
+<div class="mt-2">
+  The total number of WebNN ops is 78. These tables currently lists ops that are implemented or work in progress by multiple backends and JavaScript machine learning frameworks.
+</div>
 
 <sup>[1]</sup> XNNPack node definition in [`xnn_define_*`](https://github.com/google/XNNPACK/blob/master/include/xnnpack.h)<br/>
 <sup>[2]</sup> [DirectML](https://learn.microsoft.com/en-us/windows/win32/api/_directml/) API<br/>
-<sup>[3]</sup> TensorFlow Lite built-in operators [`kTfLiteBuiltin*`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc)<br/>
-<sup>[4]</sup> ONNX [`Operator Schemas`](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [`WebNN EP Helper`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/webnn/builders/helper.h)<br/>
-<sup>[5]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/dev/) and [Microsoft Edge](https://www.microsoftedgeinsider.com/en-us/download/canary) with `#enable-experimental-web-platform-features` flag<br/>
-<sup>[6]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/dev/) and [Microsoft Edge](https://www.microsoftedgeinsider.com/en-us/download/canary) in command line with flags on Windows 11 21H2 or higher: 
-`"%LOCALAPPDATA%\Google\Chrome SxS\Application\chrome.exe" --enable-features=MachineLearningNeuralNetworkService --enable-experimental-web-platform-features`
+<sup>[3]</sup> [MLService / TensorFlow Lite Builtin Options](https://source.chromium.org/chromium/chromium/src/+/main:third_party/tflite/src/tensorflow/lite/schema/schema_generated.h;l=1246?q=BuiltinOptions_SoftmaxOptions&ss=chromium%2Fchromium%2Fsrc)<br/>
+<sup>[4]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/dev/) and [Microsoft Edge](https://www.microsoftedgeinsider.com/en-us/download/canary) with `#web-machine-learning-neural-network` flag<br/>
+<sup>[5]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/canary/) and [Microsoft Edge](https://www.microsoftedgeinsider.com/en-us/download/canary) in command line with flags on Windows 11 21H2 or higher: 
+`"%LOCALAPPDATA%\Google\Chrome SxS\Application\chrome.exe" --enable-features=WebMachineLearningNeuralNetwork`<br/>
+<sup>[6]</sup> Enabled in [Google Chrome](https://www.google.com/chrome/dev/) with `#web-machine-learning-neural-network` flag<br/>
+<sup>[7]</sup> TensorFlow Lite built-in operators [`kTfLiteBuiltin*`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc)<br/>
+<sup>[8]</sup> ONNX [`Operator Schemas`](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [`WebNN EP Helper`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/webnn/builders/helper.h)
 
 
 <script>
@@ -222,12 +473,14 @@ The total number of WebNN ops is 78. This table currently lists ops that are imp
   
   const init = () => {
     let ops = document.querySelector('#ops');
+    let opsFramework = document.querySelector('#ops_framework');
     fetch("https://webmachinelearning.github.io/assets/json/webnn_status.json")
       .then(response => response.json())
       .then(data => {
         let impl_status = data.impl_status;
 
         let oplist = '';
+        let oplistFramework = '';
 
         for (let s of impl_status) {
 
@@ -335,6 +588,52 @@ The total number of WebNN ops is 78. This table currently lists ops that are imp
             dml = `<td></td><td>${s.dml_chromium_version_added}</td>`;
           }
 
+          let mlservice = '';
+          if (s.mlservice_op.toString().trim() === "") {
+            mlservice = `<td></td><td>${s.mlservice_chromium_version_added}</td>`;
+          } else if (s.mlservice_progress === 4) {
+            let mlservice_ops = '';
+            if (s.mlservice_op.length > 1) {
+              for (let o of s.mlservice_op) {
+                mlservice_ops = `✅ ${o} <br/>`;
+                mlservice += mlservice_ops;
+              }
+            } else if (s.mlservice_op.length === 1) {
+              mlservice = '✅ ' + s.mlservice_op;
+            } else {
+              mlservice = ``
+            }
+            mlservice = `<td class="mlservice_s">${mlservice}</td><td>${s.mlservice_chromium_version_added}</td>`;
+          } else if (s.mlservice_progress === 3) {
+            let mlservice_ops = '';
+            if (s.mlservice_op.length > 1) {
+              for (let o of s.mlservice_op) {
+                mlservice_ops = `🚀 ${o} <br/>`;
+                mlservice += mlservice_ops;
+              }
+            } else if (s.mlservice_op.length === 1) {
+              mlservice = '🚀 ' + s.mlservice_op;
+            } else {
+              mlservice = ``
+            }
+            mlservice = `<td class="mlservice_wip">${mlservice}</td><td>${s.mlservice_chromium_version_added}</td>`;
+          } else if (s.mlservice_progress === 2) {
+            let mlservice_ops = '';
+            if (s.mlservice_op.length > 1) {
+              for (let o of s.mlservice_op) {
+                mlservice_ops = `📅 ${o} <br/>`;
+                mlservice += mlservice_ops;
+              }
+            } else if (s.mlservice_op.length === 1) {
+              mlservice = '📅 ' + s.mlservice_op;
+            } else {
+              mlservice = ``
+            }
+            mlservice = `<td class="mlservice_plan">${mlservice}</td><td>${s.mlservice_chromium_version_added}</td>`;
+          } else {
+            mlservice = `<td></td><td>${s.mlservice_chromium_version_added}</td>`;
+          }
+
           let tflite = '';
           if (s.tflite_op.toString().trim() === "") {
             tflite = `<td></td><td>${s.tflite_version_added}</td>`;
@@ -433,6 +732,13 @@ The total number of WebNN ops is 78. This table currently lists ops that are imp
                 ${wpt}
                 ${xnnpack}
                 ${dml}
+                ${mlservice}
+              </tr>
+          `;
+
+          oplistFramework += `
+              <tr>
+                ${spec}
                 ${tflite}
                 ${ort}
               </tr>
@@ -445,11 +751,19 @@ The total number of WebNN ops is 78. This table currently lists ops that are imp
             <th id="wpt_total"></th>
             <th id="x_total" colspan="2"></th>
             <th id="dml_total" colspan="2"></th>
+            <th id="mlservice_total" colspan="2"></th>
+          </tr>
+        `;
+
+         oplistFramework = oplistFramework + `
+          <tr>
+            <th id="spec_total"></th>
             <th id="ed_total" colspan="2"></th>
             <th id="ep_total" colspan="2"></th>
           </tr>
         `;
         ops.innerHTML = oplist;
+        opsFramework.innerHTML = oplistFramework;
         count();
       })
       .catch(console.error);
@@ -483,6 +797,15 @@ The total number of WebNN ops is 78. This table currently lists ops that are imp
     qS('#dml_supported').innerHTML = dml_s;
     qS('#dml_partlyimplemented').innerHTML = dml_pi;
     qS('#dml_workinprogress').innerHTML = dml_wip;
+
+    let mlservice_s = qSA('.mlservice_s').length;
+    let mlservice_pi = qSA('.mlservice_pi').length;
+    let mlservice_wip = qSA('.mlservice_wip').length;
+    let mlservice_percentage = (mlservice_s / spec_defined_total * 100).toFixed(1) ;
+    qS('#mlservice_total').innerHTML = `${mlservice_s} / ${spec_defined_total}, ${mlservice_percentage}%`;
+    qS('#mlservice_supported').innerHTML = mlservice_s;
+    qS('#mlservice_partlyimplemented').innerHTML = mlservice_pi;
+    qS('#mlservice_workinprogress').innerHTML = mlservice_wip;
  
     let ed_s = qSA('.ed_s').length;
     let ed_pi = qSA('.ed_pi').length;

--- a/webnn-status.md
+++ b/webnn-status.md
@@ -474,7 +474,13 @@ sup {
   const init = () => {
     let ops = document.querySelector('#ops');
     let opsFramework = document.querySelector('#ops_framework');
-    fetch("https://webmachinelearning.github.io/assets/json/webnn_status.json")
+
+    let jsonPath = "../assets/json/webnn_status.json";
+    if(location.hostname.toLowerCase('webmachinelearning.github.io') >-1) 
+    {
+      jsonPath = "https://webmachinelearning.github.io/assets/json/webnn_status.json";
+    }
+    fetch(jsonPath)
       .then(response => response.json())
       .then(data => {
         let impl_status = data.impl_status;
@@ -757,7 +763,7 @@ sup {
 
          oplistFramework = oplistFramework + `
           <tr>
-            <th id="spec_total"></th>
+            <th id="spec2_total"></th>
             <th id="ed_total" colspan="2"></th>
             <th id="ep_total" colspan="2"></th>
           </tr>
@@ -772,9 +778,9 @@ sup {
   const count = () => {
     let spec_defined_total = 78;
 
-    let spec_s = qSA('.spec').length;
-    let spec_percentage = (spec_s / spec_defined_total * 100).toFixed(1) ;
-    qS('#spec_total').innerHTML = `${spec_s} / ${spec_defined_total}, ${spec_percentage}%`;
+    let spec_s = qSA('.spec').length / 2;
+    qS('#spec_total').innerHTML = `${spec_s}`;
+    qS('#spec2_total').innerHTML = `${spec_s}`;
   
     let wpt_s = qSA('.wpt_s').length;
     let wpt_percentage = (wpt_s / spec_defined_total * 100).toFixed(1) ;

--- a/webnn-status.md
+++ b/webnn-status.md
@@ -476,7 +476,7 @@ sup {
     let opsFramework = document.querySelector('#ops_framework');
 
     let jsonPath = "../assets/json/webnn_status.json";
-    if(location.hostname.toLowerCase('webmachinelearning.github.io') >-1) 
+    if(location.hostname.toLowerCase().indexOf('webmachinelearning.github.io') >-1) 
     {
       jsonPath = "https://webmachinelearning.github.io/assets/json/webnn_status.json";
     }


### PR DESCRIPTION
1. Updated WebNN implementation status for WPT, XNNPACK, DirectML
2. Added WebNN implementation status on ChromeOS CPU backend (MLService)
3. Split the tables into two 
- Chromium implementation status
- JS ML Framework implementation status

![10 239 115 52_4000_webnn-status_](https://github.com/webmachinelearning/webmachinelearning.github.io/assets/5017359/ead96143-9e49-4553-8b04-cc45e5710775)

@anssiko PTAL
